### PR TITLE
Add console log for editCompany status

### DIFF
--- a/company.php
+++ b/company.php
@@ -165,6 +165,9 @@ $companies = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
         <?php endif; ?>
     </form>
 </div>
+<script>
+console.log('Sayfa yüklendi. editCompany durumu:', <?= json_encode((bool)$editCompany) ?>);
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS snippet to log `editCompany` state when company page loads

## Testing
- `php -l company.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e0cf776c8328a7180bfee91ef964