### PR TITLE
Add MySQL prepare error check

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -74,6 +74,9 @@ if ($search !== '') {
 $sql .= ' ORDER BY ' . $order;
 
 $stmt = $conn->prepare($sql);
+if ($stmt === false) {
+    die('Prepare failed: ' . $conn->error);
+}
 if ($params) {
     $stmt->bind_param($types, ...$params);
 }


### PR DESCRIPTION
## Summary
- add a failure check after preparing SQL in `auth.php`

## Testing
- `php -l auth.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868f4e00bb48328858c14bac5d427fc