### PR TITLE
Apply color settings across pages

### DIFF
--- a/company.php
+++ b/company.php
@@ -47,7 +47,7 @@ $companies = $stmt->fetchAll();
     <h2 class="mb-4">Firmalar</h2>
     <div class="row mb-3">
         <div class="col-12 text-end">
-            <button type="button" class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#filterModal">
+            <button type="button" class="btn btn-<?php echo get_color(); ?> me-2" data-bs-toggle="modal" data-bs-target="#filterModal">
                 Filtrele
             </button>
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal">Firma
@@ -73,7 +73,7 @@ $companies = $stmt->fetchAll();
                     <td><?php echo htmlspecialchars($company['address']); ?></td>
                     <td><?php echo htmlspecialchars($company['email']); ?></td>
                     <td class="text-center">
-                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal"
+                        <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                             data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
                         <form method="post" action="company.php" style="display:inline-block"
                             onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
@@ -121,7 +121,7 @@ $companies = $stmt->fetchAll();
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                    <button type="submit" class="btn btn-primary">Kaydet</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
                                 </div>
                             </form>
                         </div>
@@ -156,7 +156,7 @@ $companies = $stmt->fetchAll();
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                    <button type="submit" class="btn btn-primary">Uygula</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Uygula</button>
                 </div>
             </form>
         </div>
@@ -192,7 +192,7 @@ $companies = $stmt->fetchAll();
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                    <button type="submit" class="btn btn-primary">Ekle</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Ekle</button>
                 </div>
             </form>
         </div>

--- a/customers.php
+++ b/customers.php
@@ -55,7 +55,7 @@ $customers = $stmt->fetchAll();
     <div class="row mb-3">
 
         <div class="col-12 text-end">
-            <button type="button" class="btn btn-primary me-2" data-bs-toggle="modal"
+            <button type="button" class="btn btn-<?php echo get_color(); ?> me-2" data-bs-toggle="modal"
                 data-bs-target="#filterModal">Filtrele</button>
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal">Müşteri
                 Ekle</button>
@@ -84,7 +84,7 @@ $customers = $stmt->fetchAll();
                     <td><?php echo htmlspecialchars($customer['phone']); ?></td>
                     <td><?php echo htmlspecialchars($customer['address']); ?></td>
                     <td class="text-center">
-                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal"
+                        <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                             data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
                         <form method="post" action="auth.php" style="display:inline-block"
                             onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
@@ -148,7 +148,7 @@ $customers = $stmt->fetchAll();
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                    <button type="submit" class="btn btn-primary">Kaydet</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
                                 </div>
                             </form>
                         </div>
@@ -183,7 +183,7 @@ $customers = $stmt->fetchAll();
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                    <button type="submit" class="btn btn-primary">Filtrele</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Filtrele</button>
                 </div>
             </form>
         </div>
@@ -230,7 +230,7 @@ $customers = $stmt->fetchAll();
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                    <button type="submit" class="btn btn-primary">Ekle</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Ekle</button>
                 </div>
             </form>
         </div>

--- a/dashboard.php
+++ b/dashboard.php
@@ -2,7 +2,7 @@
 <div class="container py-5 h-min">
     <div class="row justify-content-center">
         <div class="col-md-8 text-center">
-            <h1 class="display-4 mb-4">Hoş geldin,
+            <h1 class="display-4 mb-4 text-<?php echo get_color(); ?>">Hoş geldin,
                 <?php echo isset($_SESSION['user']['first_name']) ? htmlspecialchars($_SESSION['user']['first_name']) : "Kullanıcı!"; ?>
             </h1>
         </div>

--- a/login.php
+++ b/login.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'config.php';
+require_once 'helpers/theme.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -45,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Login</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="<?php echo theme_css(); ?>" rel="stylesheet">
 </head>
 
 <body class="bg-light d-flex align-items-center" style="min-height:100vh;">
@@ -74,8 +75,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     placeholder="Parola">
                             </div>
                             <div class="d-grid gap-2">
-                                <button type="submit" class="btn btn-primary">Oturum Aç</button>
-                                <a href="register.php" class="btn btn-link">Hesabın yok mu? Hemen kayıt ol</a>
+                                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Oturum Aç</button>
+                                <a href="register.php" class="btn btn-link text-<?php echo get_color(); ?>">Hesabın yok mu? Hemen kayıt ol</a>
                             </div>
                         </form>
                     </div>

--- a/product.php
+++ b/product.php
@@ -43,7 +43,7 @@ $products = $stmt->fetchAll();
     <h2 class="mb-4">Ürünler</h2>
     <div class="row mb-3">
         <div class="col-12 text-end">
-            <button type="button" class="btn btn-primary me-2" data-bs-toggle="modal"
+            <button type="button" class="btn btn-<?php echo get_color(); ?> me-2" data-bs-toggle="modal"
                 data-bs-target="#filterModal">Filtrele</button>
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addModal">Ürün
                 Ekle</button>
@@ -64,7 +64,7 @@ $products = $stmt->fetchAll();
                     <td><?php echo htmlspecialchars($product['name']); ?></td>
                     <td><?php echo htmlspecialchars($product['code']); ?></td>
                     <td class="text-center">
-                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal"
+                        <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                             data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
                         <form method="post" action="product.php" style="display:inline-block"
                             onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
@@ -102,7 +102,7 @@ $products = $stmt->fetchAll();
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                    <button type="submit" class="btn btn-primary">Kaydet</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
                                 </div>
                             </form>
                         </div>
@@ -136,7 +136,7 @@ $products = $stmt->fetchAll();
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                <button type="submit" class="btn btn-primary">Filtrele</button>
+                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Filtrele</button>
             </div>
         </form>
     </div>
@@ -163,7 +163,7 @@ $products = $stmt->fetchAll();
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                    <button type="submit" class="btn btn-primary">Ekle</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Ekle</button>
                 </div>
             </form>
         </div>

--- a/register.php
+++ b/register.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'config.php';
+require_once 'helpers/theme.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -42,7 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Kayıt Ol</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="<?php echo theme_css(); ?>" rel="stylesheet">
 </head>
 
 <body class="bg-light">
@@ -85,11 +86,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 <label for="email" class="form-label">Email</label>
                                 <input type="email" class="form-control" id="email" name="email" required>
                             </div>
-                            <button type="submit" class="btn btn-primary w-100">Kayıt Ol</button>
+                            <button type="submit" class="btn btn-<?php echo get_color(); ?> w-100">Kayıt Ol</button>
                         </form>
                         
                         <div class="text-center mt-3">
-                            <a href="login.php">Hesabın var mı? Giriş yap</a>
+                            <a href="login.php" class="link-<?php echo get_color(); ?>">Hesabın var mı? Giriş yap</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- use `get_color()` for button color on company/customer/product pages
- integrate theme and color settings on login/register pages
- show greeting text using preferred color on dashboard

## Testing
- `php -l company.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bbb8d5d1883289292c9f0dd9dadb9