### PR TITLE
Load theme on auth pages

### DIFF
--- a/helpers/theme.php
+++ b/helpers/theme.php
@@ -35,3 +35,26 @@ function get_color(): string
 {
     return $_SESSION['color'] ?? 'primary';
 }
+
+/**
+ * Load theme and color settings from the database if not already in session.
+ */
+function load_theme_settings(PDO $pdo): void
+{
+    $query = "SELECT key_name, value FROM settings
+              WHERE group_name = 'ui' AND key_name IN ('theme','color')";
+    try {
+        $stmt = $pdo->query($query);
+        foreach ($stmt as $row) {
+            $value = json_decode($row['value'], true);
+            if ($row['key_name'] === 'theme' && !isset($_SESSION['theme'])) {
+                set_theme($value);
+            }
+            if ($row['key_name'] === 'color' && !isset($_SESSION['color'])) {
+                set_color($value);
+            }
+        }
+    } catch (PDOException $e) {
+        // Silently ignore if settings table or query fails
+    }
+}

--- a/login.php
+++ b/login.php
@@ -4,6 +4,7 @@ require_once 'helpers/theme.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+load_theme_settings($pdo);
 
 $errors = [];
 $username = '';

--- a/register.php
+++ b/register.php
@@ -4,6 +4,7 @@ require_once 'helpers/theme.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+load_theme_settings($pdo);
 
 $errors = [];
 $success = '';


### PR DESCRIPTION
## Summary
- ensure theme settings can load from the database
- apply theme settings on login and registration pages

## Testing
- `php -l helpers/theme.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bce3b82288328b92d9ec72aac0e9b