### PR TITLE
Add theme loading for main pages

### DIFF
--- a/company.php
+++ b/company.php
@@ -1,5 +1,10 @@
 <?php
 require_once 'config.php';
+require_once 'helpers/theme.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+load_theme_settings($pdo);
 include 'includes/header.php';
 
 // Handle Add Company

--- a/customers.php
+++ b/customers.php
@@ -1,5 +1,10 @@
 <?php
 require_once 'config.php';
+require_once 'helpers/theme.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+load_theme_settings($pdo);
 include 'includes/header.php';
 
 // Load companies for dropdowns

--- a/dashboard.php
+++ b/dashboard.php
@@ -1,4 +1,12 @@
-<?php include 'includes/header.php'; ?>
+<?php
+require_once 'config.php';
+require_once 'helpers/theme.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+load_theme_settings($pdo);
+include 'includes/header.php';
+?>
 <div class="container py-5 h-min">
     <div class="row justify-content-center">
         <div class="col-md-8 text-center">

--- a/product.php
+++ b/product.php
@@ -1,5 +1,10 @@
 <?php
 require_once 'config.php';
+require_once 'helpers/theme.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+load_theme_settings($pdo);
 include 'includes/header.php';
 
 // CRUD Actions


### PR DESCRIPTION
## Summary
- load theme settings in company, customer, product and dashboard pages

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcf63d72083289235ac351f60b5a5