### PR TITLE
Add icons for list/card view toggle

### DIFF
--- a/company.php
+++ b/company.php
@@ -69,8 +69,8 @@ $companies = $stmt->fetchAll();
             <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal" data-bs-target="#addModal">Firma
                 Ekle</button>
             <div class="btn-group ms-2" role="group">
-                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>">Liste</a>
-                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>">Kart</a>
+                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
+                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
             </div>
         </div>
     </div>

--- a/customers.php
+++ b/customers.php
@@ -93,8 +93,8 @@ $customers = $stmt->fetchAll();
                 <a href="company" class="btn btn-<?php echo get_color(); ?>">Firma Ekle</a>
             <?php endif; ?>
             <div class="btn-group ms-2" role="group">
-                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>">Liste</a>
-                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>">Kart</a>
+                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
+                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
             </div>
         </div>
     </div>

--- a/includes/header.php
+++ b/includes/header.php
@@ -5,6 +5,7 @@ if (session_status() === PHP_SESSION_NONE) {
 require_once __DIR__ . '/../helpers/theme.php';
 ?>
 <link href="<?php echo theme_css(); ?>" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 <nav
     class="navbar navbar-expand-lg <?php echo get_theme() === 'dark' ? 'navbar-dark bg-dark' : 'navbar-light bg-light'; ?>">
     <div class="container">

--- a/offer.php
+++ b/offer.php
@@ -85,8 +85,8 @@ include 'includes/header.php';
                 <a href="offer_form" class="btn btn-<?php echo get_color(); ?>">Teklif Ekle</a>
             <?php endif; ?>
             <div class="btn-group ms-2" role="group">
-                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>">Liste</a>
-                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>">Kart</a>
+                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
+                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
             </div>
         </div>
     </div>

--- a/product.php
+++ b/product.php
@@ -98,8 +98,8 @@ $products = $stmt->fetchAll();
                 data-bs-target="#addModal">Ürün
                 Ekle</button>
             <div class="btn-group ms-2" role="group">
-                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>">Liste</a>
-                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>">Kart</a>
+                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
+                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- include Bootstrap Icons in the header
- show icons instead of text for list and card view buttons on company, customer, product and offer pages

## Testing
- `php -l includes/header.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_6870b0644d18832882830587b8292e3c