### PR TITLE
Add quantity calculations in optimization

### DIFF
--- a/optimization.php
+++ b/optimization.php
@@ -37,33 +37,51 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $zincir = $son_kapatma + 600;
     $flatbelt_kayis = $son_kapatma + 600;
     $motor_borusu = $width - 59;
+
+    // parça adet hesapları
+    $motor_kutusu_qty = $quantity;
+    $motor_kapak_qty = $quantity;
+    $alt_kasa_qty = $quantity;
+    $kenetli_baza_qty = 2 * $quantity;
+    $kupeste_baza_qty = 2 * $quantity;
+    $tutamak_qty = 6 * $quantity * $kenetli_baza_qty * $kupeste_baza_qty;
+    $kupeste_qty = $quantity;
+    $yatay_citasi_qty = 6 * $quantity;
+    $dikey_citasi_qty = 6 * $quantity;
+    $dikme_qty = 2 * $quantity;
+    $orta_dikme_qty = 2 * $quantity;
+    $son_kapatma_qty = 2 * $quantity;
+    $kanat_qty = 2 * $quantity;
+    $dikey_baza_qty = 4 * $quantity;
+    $zincir_qty = 2 * $quantity;
+    $motor_borusu_qty = $quantity;
     $motor_kutu_contasi = (($motor_kutusu * $quantity) + ($alt_kasa * $quantity)) / 1000;
     $kanat_contasi = $kanat * $quantity * 2 / 1000;
     $kenet_fitili = (($tutamak * $quantity) + ($kenetli_baza * $quantity)) / 1000;
     $kil_fitil = (($dikme * $quantity) + ($orta_dikme * $quantity * 2) + ($son_kapatma * $quantity) + ($kanat * $quantity)) / 1000;
 
     $results = [
-        'Motor Kutusu' => $motor_kutusu,
-        'Motor Kapak' => $motor_kapak,
-        'Alt Kasa' => $alt_kasa,
-        'Tutamak' => $tutamak,
-        'Kenetli Baza' => $kenetli_baza,
-        'Küpeşte Baza' => $kupeste_baza,
-        'Küpeşte' => $kupeste,
-        'Yatak Tek Cam Çıtası' => $yatak_citasi,
-        'Dikey Tek Cam Çıtası' => $dikey_citasi,
-        'Dikme' => $dikme,
-        'Orta Dikme' => $orta_dikme,
-        'Son Kapatma' => $son_kapatma,
-        'Kanat' => $kanat,
-        'Dikey Baza' => $dikey_baza,
-        'Zincir' => $zincir,
-        'Flatbelt Kayış' => $flatbelt_kayis,
-        'Motor Borusu' => $motor_borusu,
-        'Motor Kutu Contası (m)' => $motor_kutu_contasi,
-        'Kanat Contası (m)' => $kanat_contasi,
-        'Kenet Fitili (m)' => $kenet_fitili,
-        'Kıl Fitil (m)' => $kil_fitil,
+        ['name' => 'Motor Kutusu', 'length' => $motor_kutusu, 'count' => $motor_kutusu_qty],
+        ['name' => 'Motor Kapak', 'length' => $motor_kapak, 'count' => $motor_kapak_qty],
+        ['name' => 'Alt Kasa', 'length' => $alt_kasa, 'count' => $alt_kasa_qty],
+        ['name' => 'Tutamak', 'length' => $tutamak, 'count' => $tutamak_qty],
+        ['name' => 'Kenetli Baza', 'length' => $kenetli_baza, 'count' => $kenetli_baza_qty],
+        ['name' => 'Küpeşte Baza', 'length' => $kupeste_baza, 'count' => $kupeste_baza_qty],
+        ['name' => 'Küpeşte', 'length' => $kupeste, 'count' => $kupeste_qty],
+        ['name' => 'Yatay Tek Cam Çıtası', 'length' => $yatak_citasi, 'count' => $yatay_citasi_qty],
+        ['name' => 'Dikey Tek Cam Çıtası', 'length' => $dikey_citasi, 'count' => $dikey_citasi_qty],
+        ['name' => 'Dikme', 'length' => $dikme, 'count' => $dikme_qty],
+        ['name' => 'Orta Dikme', 'length' => $orta_dikme, 'count' => $orta_dikme_qty],
+        ['name' => 'Son Kapatma', 'length' => $son_kapatma, 'count' => $son_kapatma_qty],
+        ['name' => 'Kanat', 'length' => $kanat, 'count' => $kanat_qty],
+        ['name' => 'Dikey Baza', 'length' => $dikey_baza, 'count' => $dikey_baza_qty],
+        ['name' => 'Zincir', 'length' => $zincir, 'count' => $zincir_qty],
+        ['name' => 'Flatbelt Kayış', 'length' => $flatbelt_kayis, 'count' => '-'],
+        ['name' => 'Motor Borusu', 'length' => $motor_borusu, 'count' => $motor_borusu_qty],
+        ['name' => 'Motor Kutu Contası (m)', 'length' => $motor_kutu_contasi, 'count' => '-'],
+        ['name' => 'Kanat Contası (m)', 'length' => $kanat_contasi, 'count' => '-'],
+        ['name' => 'Kenet Fitili (m)', 'length' => $kenet_fitili, 'count' => '-'],
+        ['name' => 'Kıl Fitil (m)', 'length' => $kil_fitil, 'count' => '-'],
     ];
 }
 ?>
@@ -96,11 +114,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </form>
         <?php if ($results): ?>
             <table class="table table-bordered">
-                <tbody>
-                <?php foreach ($results as $key => $value): ?>
+                <thead>
                     <tr>
-                        <th><?php echo htmlspecialchars($key); ?></th>
-                        <td><?php echo round($value, 2); ?></td>
+                        <th>Parça</th>
+                        <th>Uzunluk</th>
+                        <th>Adet</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($results as $row): ?>
+                    <tr>
+                        <th><?php echo htmlspecialchars($row['name']); ?></th>
+                        <td><?php echo round($row['length'], 2); ?></td>
+                        <td><?php echo htmlspecialchars($row['count']); ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>


### PR DESCRIPTION
## Summary
- calculate part quantities based on system count
- show length and quantity in optimization results table

## Testing
- `php -l optimization.php`
- `ls *.php | xargs -I{} php -l {}`
- `find helpers includes -name '*.php' -print0 | xargs -0 -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_6870ba2159fc83289430db5505a8c2a7