### PR TITLE
Add standalone sort dropdowns

### DIFF
--- a/company.php
+++ b/company.php
@@ -63,15 +63,28 @@ $companies = $stmt->fetchAll();
     <h2 class="mb-4">Firmalar</h2>
     <div class="row mb-3">
         <div class="col-12 text-end">
+            <form method="get" class="d-inline-block me-2">
+                <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Firma ara" style="display:inline-block;width:auto;">
+                <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
+            <form method="get" class="d-inline-block me-2">
+                <select name="sort" class="form-select d-inline-block w-auto">
+                    <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                    <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                </select>
+                <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
             <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal" data-bs-target="#filterModal">
                 Filtrele
             </button>
             <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal" data-bs-target="#addModal">Firma
                 Ekle</button>
-                <div class="btn-group ms-2" role="group">
-                    <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
-                    <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
-                </div>
+            <div class="btn-group ms-2" role="group">
+                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
+                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
+            </div>
         </div>
     </div>
 

--- a/customers.php
+++ b/customers.php
@@ -84,6 +84,19 @@ $customers = $stmt->fetchAll();
     <div class="row mb-3">
 
         <div class="col-12 text-end">
+            <form method="get" class="d-inline-block me-2">
+                <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Müşteri ara" style="display:inline-block;width:auto;">
+                <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
+            <form method="get" class="d-inline-block me-2">
+                <select name="sort" class="form-select d-inline-block w-auto">
+                    <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                    <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                </select>
+                <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
             <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal"
                 data-bs-target="#filterModal">Filtrele</button>
             <?php if ($canAddCustomer): ?>

--- a/offer.php
+++ b/offer.php
@@ -92,6 +92,19 @@ include 'includes/header.php';
     <?php endif; ?>
     <div class="row mb-3">
         <div class="col-12 text-end">
+            <form method="get" class="d-inline-block me-2">
+                <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Teklif ara" style="display:inline-block;width:auto;">
+                <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
+            <form method="get" class="d-inline-block me-2">
+                <select name="sort" class="form-select d-inline-block w-auto">
+                    <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                    <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                </select>
+                <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+            </form>
             <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal" data-bs-target="#filterModal">Filtrele</button>
             <?php if ($canAdd): ?>
                 <a href="offer_form" class="btn btn-<?php echo get_color(); ?>">Teklif Ekle</a>

--- a/product.php
+++ b/product.php
@@ -92,6 +92,22 @@ $products = $stmt->fetchAll();
     <h2 class="mb-4">Ürünler</h2>
     <div class="row mb-3">
         <div class="col-12 text-end">
+            <form method="get" class="d-inline-block me-2">
+                <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>"
+                    class="form-control" placeholder="Ürün ara" style="display:inline-block;width:auto;">
+                <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                <input type="hidden" name="category" value="<?php echo htmlspecialchars($categoryFilter); ?>">
+            </form>
+            <form method="get" class="d-inline-block me-2">
+                <select name="sort" class="form-select d-inline-block w-auto">
+                    <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                    <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                </select>
+                <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                <input type="hidden" name="category" value="<?php echo htmlspecialchars($categoryFilter); ?>">
+            </form>
             <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal"
                 data-bs-target="#filterModal">Filtrele</button>
             <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"


### PR DESCRIPTION
## Summary
- expose sorting options next to search box on company, customers, product and offer pages
- keep current query parameters when sorting or searching

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_6870c46db85c832897c57b871e21dfbc