### PR TITLE
Remove filter buttons

### DIFF
--- a/company.php
+++ b/company.php
@@ -76,9 +76,6 @@ $companies = $stmt->fetchAll();
                 <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
             </form>
-            <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal" data-bs-target="#filterModal">
-                Filtrele
-            </button>
             <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal" data-bs-target="#addModal">Firma
                 Ekle</button>
             <div class="btn-group ms-2" role="group">

--- a/customers.php
+++ b/customers.php
@@ -97,8 +97,6 @@ $customers = $stmt->fetchAll();
                 <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
             </form>
-            <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal"
-                data-bs-target="#filterModal">Filtrele</button>
             <?php if ($canAddCustomer): ?>
                 <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal" data-bs-target="#addModal">Müşteri
                     Ekle</button>

--- a/offer.php
+++ b/offer.php
@@ -105,7 +105,6 @@ include 'includes/header.php';
                 <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
             </form>
-            <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal" data-bs-target="#filterModal">Filtrele</button>
             <?php if ($canAdd): ?>
                 <a href="offer_form" class="btn btn-<?php echo get_color(); ?>">Teklif Ekle</a>
             <?php endif; ?>

--- a/product.php
+++ b/product.php
@@ -108,8 +108,6 @@ $products = $stmt->fetchAll();
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
                 <input type="hidden" name="category" value="<?php echo htmlspecialchars($categoryFilter); ?>">
             </form>
-            <button type="button" class="btn btn-dark me-2" data-bs-toggle="modal"
-                data-bs-target="#filterModal">Filtrele</button>
             <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                 data-bs-target="#addModal">Ürün
                 Ekle</button>


### PR DESCRIPTION
## Summary
- remove `Filtrele` buttons from customer, product, company and offer pages

## Testing
- `php -l customers.php`
- `php -l product.php`
- `php -l company.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_6870c67bbdc483288ee8401de1957639