### PR TITLE
Implement search via enter key and button

### DIFF
--- a/company.php
+++ b/company.php
@@ -67,6 +67,7 @@ $companies = $stmt->fetchAll();
                 <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Firma ara" style="display:inline-block;width:auto;">
                 <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
                 <select name="sort" class="form-select d-inline-block w-auto">

--- a/customers.php
+++ b/customers.php
@@ -88,6 +88,7 @@ $customers = $stmt->fetchAll();
                 <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Müşteri ara" style="display:inline-block;width:auto;">
                 <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
                 <select name="sort" class="form-select d-inline-block w-auto">

--- a/includes/header.php
+++ b/includes/header.php
@@ -45,8 +45,9 @@ require_once __DIR__ . '/../helpers/theme.php';
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('input[type="text"][name="search"]').forEach(function (input) {
-        input.addEventListener('keyup', function () {
-            if (input.form) {
+        input.addEventListener('keypress', function (e) {
+            if (e.key === 'Enter' && input.form) {
+                e.preventDefault();
                 input.form.submit();
             }
         });

--- a/offer.php
+++ b/offer.php
@@ -96,6 +96,7 @@ include 'includes/header.php';
                 <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Teklif ara" style="display:inline-block;width:auto;">
                 <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
                 <select name="sort" class="form-select d-inline-block w-auto">

--- a/product.php
+++ b/product.php
@@ -98,6 +98,7 @@ $products = $stmt->fetchAll();
                 <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
                 <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
                 <input type="hidden" name="category" value="<?php echo htmlspecialchars($categoryFilter); ?>">
+                <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
                 <select name="sort" class="form-select d-inline-block w-auto">


### PR DESCRIPTION
## Summary
- allow search input to submit only when Enter is pressed
- add explicit "Ara" buttons to search forms

## Testing
- `php -l includes/header.php`
- `php -l product.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_6870cd5acf9483289333a524228bc1bf