### PR TITLE
Add session token creation on login

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -17,5 +17,9 @@ include 'includes/header.php';
             <h1 class="display-4 mb-4 text-<?php echo get_color(); ?>">Hoş geldin,
                 <?php echo isset($_SESSION['user']['first_name']) ? htmlspecialchars($_SESSION['user']['first_name']) : "Kullanıcı!"; ?>
             </h1>
+            <?php if (isset($_SESSION['token'])): ?>
+                <p class="text-muted">Token: <code><?php echo htmlspecialchars($_SESSION['token']); ?></code></p>
+            <?php endif; ?>
         </div>
-    </div></div>
+    </div>
+</div>

--- a/login.php
+++ b/login.php
@@ -29,6 +29,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'last_name' => $user['last_name'],
                     'email' => $user['email']
                 ];
+                // Create a session token on successful login
+                $token = bin2hex(random_bytes(32));
+                $_SESSION['token'] = $token;
+                setcookie('token', $token, time() + 3600, '/', '', false, true);
                 header('Location: dashboard');
                 exit;
             } else {

--- a/logout.php
+++ b/logout.php
@@ -5,6 +5,8 @@ if (session_status() === PHP_SESSION_NONE) {
 
 session_unset();
 session_destroy();
+// Remove the token cookie when logging out
+setcookie('token', '', time() - 3600, '/', '', false, true);
 
 header('Location: /login');
 exit;


### PR DESCRIPTION
## Summary
- create and store a random token when the user logs in
- display the token on the dashboard
- clear the token cookie on logout

## Testing
- `php -l login.php`
- `php -l dashboard.php`
- `php -l logout.php`

------
https://chatgpt.com/codex/tasks/task_e_6870cfd98d30832887dedb4a332790b6