### PR TITLE
Enable auto-submit for sort dropdowns

### DIFF
--- a/company.php
+++ b/company.php
@@ -70,7 +70,7 @@ $companies = $stmt->fetchAll();
                 <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
-                <select name="sort" class="form-select d-inline-block w-auto">
+                <select name="sort" class="form-select d-inline-block w-auto" onchange="this.form.submit()">
                     <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
                     <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
                 </select>

--- a/customers.php
+++ b/customers.php
@@ -101,7 +101,7 @@ $customers = $stmt->fetchAll();
                 <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
-                <select name="sort" class="form-select d-inline-block w-auto">
+                <select name="sort" class="form-select d-inline-block w-auto" onchange="this.form.submit()">
                     <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
                     <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
                 </select>

--- a/offer.php
+++ b/offer.php
@@ -110,7 +110,7 @@ include 'includes/header.php';
                 <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
-                <select name="sort" class="form-select d-inline-block w-auto">
+                <select name="sort" class="form-select d-inline-block w-auto" onchange="this.form.submit()">
                     <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
                     <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
                 </select>

--- a/product.php
+++ b/product.php
@@ -111,7 +111,7 @@ $products = $stmt->fetchAll();
                 <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
             </form>
             <form method="get" class="d-inline-block me-2">
-                <select name="sort" class="form-select d-inline-block w-auto">
+                <select name="sort" class="form-select d-inline-block w-auto" onchange="this.form.submit()">
                     <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
                     <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
                 </select>


### PR DESCRIPTION
## Summary
- trigger sorting immediately after the user selects a sort order

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l offer.php`
- `php -l product.php`


------
https://chatgpt.com/codex/tasks/task_e_6870f591bc7c8328b04c649d2022d2af