### PR TITLE
Add glass dimension calculations to optimization

### DIFF
--- a/optimization.php
+++ b/optimization.php
@@ -49,6 +49,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $flatbelt_kayis = $son_kapatma + 600;
     $motor_borusu = $width - 59;
 
+    // Cam ölçüleri
+    $cam_en = $width - 221;
+    $cam_boy = $dikey_baza + 26;
+
     // parça adet hesapları
     $motor_kutusu_qty = $quantity;
     $motor_kapak_qty = $quantity;
@@ -76,6 +80,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $kenet_fitili = (($tutamak * $quantity) + ($kenetli_baza * $quantity)) / 1000;
     $kil_fitil = (($dikme * $quantity) + ($orta_dikme * $quantity * 2) + ($son_kapatma * $quantity) + ($kanat * $quantity)) / 1000;
 
+    $cam_adet = ($kanat_qty + $dikey_baza_qty) / 2;
+
     $results = [
         ['name' => 'Motor Kutusu', 'length' => $motor_kutusu, 'count' => $motor_kutusu_qty],
         ['name' => 'Motor Kapak', 'length' => $motor_kapak, 'count' => $motor_kapak_qty],
@@ -91,6 +97,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         ['name' => 'Son Kapatma', 'length' => $son_kapatma, 'count' => $son_kapatma_qty],
         ['name' => 'Kanat', 'length' => $kanat, 'count' => $kanat_qty],
         ['name' => 'Dikey Baza', 'length' => $dikey_baza, 'count' => $dikey_baza_qty],
+        ['name' => 'Cam', 'length' => $cam_en . ' x ' . $cam_boy, 'count' => $cam_adet],
         ['name' => 'Zincir', 'length' => $zincir, 'count' => $zincir_qty],
         ['name' => 'Flatbelt Kayış', 'length' => $flatbelt_kayis, 'count' => '-'],
         ['name' => 'Motor Borusu', 'length' => $motor_borusu, 'count' => $motor_borusu_qty],
@@ -108,8 +115,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $row['cost'] = null;
         if ($product) {
             $count = is_numeric($row['count']) ? (float)$row['count'] : 0;
-            $length = $row['length'];
-            if (strpos($row['name'], '(m)') === false) {
+            $length = is_numeric($row['length']) ? (float)$row['length'] : 0;
+            if (strpos($row['name'], '(m)') === false && is_numeric($row['length'])) {
                 $length = $row['length'] / 1000; // convert mm to m
             }
             switch (strtolower($product['unit'])) {
@@ -179,7 +186,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <?php foreach ($results as $row): ?>
                     <tr>
                         <th><?php echo htmlspecialchars($row['name']); ?></th>
-                        <td><?php echo round($row['length'], 2); ?></td>
+                        <td>
+                            <?php
+                                echo is_numeric($row['length'])
+                                    ? round($row['length'], 2)
+                                    : htmlspecialchars($row['length']);
+                            ?>
+                        </td>
                         <td><?php echo htmlspecialchars($row['count']); ?></td>
                         <td>
                             <?php echo is_null($row['cost']) ? '-' : number_format($row['cost'], 2); ?>


### PR DESCRIPTION
## Summary
- compute glass width, height, and quantity
- include glass row in optimization results
- handle display of non-numeric dimensions

## Testing
- `php -l optimization.php`
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6871f2ede6a0832895843632f706e3f0