### PR TITLE
Implement audit logging for CRUD operations

### DIFF
--- a/company.php
+++ b/company.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/audit.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -22,6 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':address' => $_POST['address'],
             ':email' => $_POST['email']
         ]);
+        audit_log($pdo, 'companies', $pdo->lastInsertId(), 'create');
         header('Location: company');
         exit;
     } elseif ($action === 'edit') {
@@ -33,11 +35,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':email' => $_POST['email'],
             ':id' => $_POST['id']
         ]);
+        audit_log($pdo, 'companies', $_POST['id'], 'update');
         header('Location: company');
         exit;
     } elseif ($action === 'delete') {
         $stmt = $pdo->prepare("DELETE FROM companies WHERE id = :id");
         $stmt->execute([':id' => $_POST['id']]);
+        audit_log($pdo, 'companies', $_POST['id'], 'delete');
         header('Location: company');
         exit;
     }

--- a/customers.php
+++ b/customers.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/audit.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -30,6 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':phone' => $_POST['phone'],
             ':address' => $_POST['address']
         ]);
+        audit_log($pdo, 'customers', $pdo->lastInsertId(), 'create');
         header('Location: customers');
         exit;
     } elseif ($action === 'edit') {
@@ -44,11 +46,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':address' => $_POST['address'],
             ':id' => $_POST['id']
         ]);
+        audit_log($pdo, 'customers', $_POST['id'], 'update');
         header('Location: customers');
         exit;
     } elseif ($action === 'delete') {
         $stmt = $pdo->prepare("DELETE FROM customers WHERE id = :id");
         $stmt->execute([':id' => $_POST['id']]);
+        audit_log($pdo, 'customers', $_POST['id'], 'delete');
         header('Location: customers');
         exit;
     }

--- a/helpers/audit.php
+++ b/helpers/audit.php
@@ -1,0 +1,34 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Log create/update/delete actions to the audit_logs table.
+ */
+function audit_log(PDO $pdo, string $table, $recordId, string $action): void
+{
+    $userId = $_SESSION['user']['id'] ?? null;
+    $actionMap = [
+        'create' => 1,
+        'update' => 2,
+        'delete' => 3,
+    ];
+    $actionId = $actionMap[strtolower($action)] ?? null;
+    if ($actionId === null) {
+        return;
+    }
+    try {
+        $stmt = $pdo->prepare(
+            'INSERT INTO audit_logs (user_id, table_name, record_id, action_id) VALUES (:user, :table_name, :record_id, :action_id)'
+        );
+        $stmt->execute([
+            ':user' => $userId,
+            ':table_name' => $table,
+            ':record_id' => $recordId,
+            ':action_id' => $actionId,
+        ]);
+    } catch (PDOException $e) {
+        // Do not interrupt application flow if audit logging fails
+    }
+}

--- a/offer.php
+++ b/offer.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/audit.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -44,6 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':validity'  => $_POST['quote_validity'],
             ':maturity'  => $_POST['maturity']
         ]);
+        audit_log($pdo, 'master_quotes', $pdo->lastInsertId(), 'create');
         header('Location: offer');
         exit;
     } elseif ($action === 'edit') {
@@ -59,11 +61,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':maturity' => $_POST['maturity'],
             ':id'       => $_POST['id']
         ]);
+        audit_log($pdo, 'master_quotes', $_POST['id'], 'update');
         header('Location: offer');
         exit;
     } elseif ($action === 'delete') {
         $stmt = $pdo->prepare("DELETE FROM master_quotes WHERE id=:id");
         $stmt->execute([':id' => $_POST['id']]);
+        audit_log($pdo, 'master_quotes', $_POST['id'], 'delete');
         header('Location: offer');
         exit;
     }

--- a/offer_form.php
+++ b/offer_form.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/audit.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -175,6 +176,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
     }
 
     $stmt->execute($data);
+    if ($id) {
+        audit_log($pdo, 'master_quotes', $id, 'update');
+    } else {
+        audit_log($pdo, 'master_quotes', $pdo->lastInsertId(), 'create');
+    }
     header('Location: offer');
     exit;
 }

--- a/product.php
+++ b/product.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/audit.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -42,6 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':unit_price' => $_POST['unit_price'],
             ':category' => $category
         ]);
+        audit_log($pdo, 'products', $pdo->lastInsertId(), 'create');
         header('Location: product');
         exit;
     } elseif ($action === 'edit') {
@@ -55,11 +57,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':category' => $category,
             ':id' => $_POST['id']
         ]);
+        audit_log($pdo, 'products', $_POST['id'], 'update');
         header('Location: product');
         exit;
     } elseif ($action === 'delete') {
         $stmt = $pdo->prepare("DELETE FROM products WHERE id = :id");
         $stmt->execute([':id' => $_POST['id']]);
+        audit_log($pdo, 'products', $_POST['id'], 'delete');
         header('Location: product');
         exit;
     }


### PR DESCRIPTION
## Summary
- create `helpers/audit.php` for writing to `audit_logs`
- log create/update/delete actions in company, customer, product and quote flows

## Testing
- `php -l helpers/audit.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`
- `php -l offer_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68721c750bf08328ba69774334dfd573