### PR TITLE
Add audit log viewer with buttons

### DIFF
--- a/company.php
+++ b/company.php
@@ -126,7 +126,7 @@ $companies = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
-                                <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="company" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -201,7 +201,7 @@ $companies = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
-                                    <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                    <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="company" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/company.php
+++ b/company.php
@@ -126,6 +126,7 @@ $companies = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
+                                <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                 <form method="post" action="company" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -200,6 +201,7 @@ $companies = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
+                                    <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                     <form method="post" action="company" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/customers.php
+++ b/customers.php
@@ -158,7 +158,7 @@ $customers = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
-                                <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="customers" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -260,7 +260,7 @@ $customers = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
-                                    <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                    <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="customers" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/customers.php
+++ b/customers.php
@@ -158,6 +158,7 @@ $customers = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
+                                <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                 <form method="post" action="customers" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -259,6 +260,7 @@ $customers = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
+                                    <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                     <form method="post" action="customers" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/log-list.php
+++ b/log-list.php
@@ -1,0 +1,69 @@
+<?php
+require_once 'config.php';
+require_once 'helpers/theme.php';
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($_SESSION['user'])) {
+    header('Location: /login');
+    exit;
+}
+load_theme_settings($pdo);
+
+$table = $_GET['table'] ?? '';
+$recordId = $_GET['id'] ?? '';
+$allowed = ['companies', 'customers', 'products', 'master_quotes'];
+if (!in_array($table, $allowed, true) || $recordId === '') {
+    echo 'Geçersiz istek';
+    exit;
+}
+
+$stmt = $pdo->prepare(
+    'SELECT al.action_time, al.id, u.username, CONCAT(u.first_name, " ", u.last_name) AS full_name
+     FROM audit_logs al
+     LEFT JOIN users u ON al.user_id = u.id
+     WHERE al.table_name = :table AND al.record_id = :record
+     ORDER BY al.action_time DESC'
+);
+$stmt->execute([
+    ':table' => $table,
+    ':record' => $recordId
+]);
+$logs = $stmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Log Kayıtları</title>
+    <link href="<?php echo theme_css(); ?>" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <?php include 'includes/header.php'; ?>
+    <div class="container py-4">
+        <h2 class="mb-4">Log Kayıtları</h2>
+        <table class="table table-bordered table-striped">
+            <thead>
+                <tr>
+                    <th>Tarih ve Saat</th>
+                    <th>ID</th>
+                    <th>Kullanıcı Adı</th>
+                    <th>İsim Soyisim</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($logs as $log): ?>
+                    <tr>
+                        <td><?php echo htmlspecialchars($log['action_time']); ?></td>
+                        <td><?php echo htmlspecialchars($log['id']); ?></td>
+                        <td><?php echo htmlspecialchars($log['username']); ?></td>
+                        <td><?php echo htmlspecialchars($log['full_name']); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <a href="javascript:history.back()" class="btn btn-secondary">Geri</a>
+    </div>
+</body>
+</html>

--- a/offer.php
+++ b/offer.php
@@ -159,7 +159,7 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
                     <td class="text-center">
                         <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
-                        <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                        <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                         <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
@@ -188,7 +188,7 @@ include 'includes/header.php';
                         </p>
                         <div class="text-end">
                             <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
-                            <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                            <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                             <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?php echo $q['id']; ?>">

--- a/offer.php
+++ b/offer.php
@@ -159,6 +159,7 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
                     <td class="text-center">
                         <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
+                        <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                         <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
@@ -187,6 +188,7 @@ include 'includes/header.php';
                         </p>
                         <div class="text-end">
                             <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
+                            <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                             <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?php echo $q['id']; ?>">

--- a/product.php
+++ b/product.php
@@ -177,7 +177,7 @@ $products = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
-                                <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="product" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -280,7 +280,7 @@ $products = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
-                                    <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info">İncele</a>
+                                    <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="product" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/product.php
+++ b/product.php
@@ -177,6 +177,7 @@ $products = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
+                                <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                 <form method="post" action="product" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -279,6 +280,7 @@ $products = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
+                                    <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info">İncele</a>
                                     <form method="post" action="product" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">


### PR DESCRIPTION
## Summary
- enable viewing of audit logs for companies, customers, products and offers
- create **log-list.php** page to show audit log entries
- link to the new log list with "İncele" buttons on list and card views

## Testing
- `php -l log-list.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_68721e95ddc08328a472f74a5f253b31