### PR TITLE
Add icons to action buttons

### DIFF
--- a/company.php
+++ b/company.php
@@ -125,13 +125,13 @@ $companies = $stmt->fetchAll();
                             <td><?php echo htmlspecialchars($company['email']); ?></td>
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
+                                    data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                 <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="company" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                 </form>
                             </td>
                         </tr>
@@ -200,13 +200,13 @@ $companies = $stmt->fetchAll();
                                 </p>
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $company['id']; ?>">Düzenle</button>
+                                        data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                     <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="company" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                     </form>
                                 </div>
                             </div>

--- a/customers.php
+++ b/customers.php
@@ -157,13 +157,13 @@ $customers = $stmt->fetchAll();
                             <td><?php echo htmlspecialchars($customer['address']); ?></td>
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
+                                    data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                 <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="customers" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                 </form>
                             </td>
                         </tr>
@@ -259,13 +259,13 @@ $customers = $stmt->fetchAll();
                                 </p>
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $customer['id']; ?>">Düzenle</button>
+                                        data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                     <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="customers" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                     </form>
                                 </div>
                             </div>

--- a/offer.php
+++ b/offer.php
@@ -158,12 +158,12 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['quote_validity']); ?></td>
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
                     <td class="text-center">
-                        <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
+                        <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>"><i class="bi bi-pencil"></i> Düzenle</a>
                         <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                         <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
-                            <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                            <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                         </form>
                     </td>
                 </tr>
@@ -187,12 +187,12 @@ include 'includes/header.php';
                             Vade: <?php echo htmlspecialchars($q['maturity']); ?>
                         </p>
                         <div class="text-end">
-                            <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>">Düzenle</a>
+                            <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm btn-<?php echo get_color(); ?>"><i class="bi bi-pencil"></i> Düzenle</a>
                             <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                             <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
-                                <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                             </form>
                         </div>
                     </div>

--- a/product.php
+++ b/product.php
@@ -176,13 +176,13 @@ $products = $stmt->fetchAll();
                             <td><?php echo htmlspecialchars($product['category']); ?></td>
                             <td class="text-center">
                                 <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
+                                    data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                 <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                 <form method="post" action="product" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                 </form>
                             </td>
                         </tr>
@@ -279,13 +279,13 @@ $products = $stmt->fetchAll();
                                 </p>
                                 <div class="text-end">
                                     <button class="btn btn-sm btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $product['id']; ?>">Düzenle</button>
+                                        data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
                                     <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm btn-info" title="Logları Gör"><i class="bi bi-eye"></i></a>
                                     <form method="post" action="product" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger">Sil</button>
+                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i> Sil</button>
                                     </form>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add edit and trash icons to action buttons in company, customers, product and offer pages

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_687221ca52d08328a13211ae7df594af