### PR TITLE
Restrict log pages to admins

### DIFF
--- a/company.php
+++ b/company.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/auth.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -126,7 +127,9 @@ $companies = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                <?php if (is_admin($pdo)): ?>
                                 <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                <?php endif; ?>
                                 <form method="post" action="company" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -201,7 +204,9 @@ $companies = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                    <?php if (is_admin($pdo)): ?>
                                     <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                    <?php endif; ?>
                                     <form method="post" action="company" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/customers.php
+++ b/customers.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/auth.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -158,7 +159,9 @@ $customers = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                <?php if (is_admin($pdo)): ?>
                                 <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                <?php endif; ?>
                                 <form method="post" action="customers" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -260,7 +263,9 @@ $customers = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                    <?php if (is_admin($pdo)): ?>
                                     <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                    <?php endif; ?>
                                     <form method="post" action="customers" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">

--- a/helpers/auth.php
+++ b/helpers/auth.php
@@ -1,0 +1,28 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Check if the currently logged in user has the admin role.
+ */
+function is_admin(PDO $pdo): bool
+{
+    $userId = $_SESSION['user']['id'] ?? null;
+    if ($userId === null) {
+        return false;
+    }
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT r.name FROM roles r ' .
+            'JOIN role_user ru ON r.id = ru.role_id ' .
+            'WHERE ru.user_id = ? LIMIT 1'
+        );
+        $stmt->execute([$userId]);
+        $role = $stmt->fetchColumn();
+        return $role === 'admin';
+    } catch (PDOException $e) {
+        return false;
+    }
+}
+?>

--- a/log-list.php
+++ b/log-list.php
@@ -1,11 +1,16 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/auth.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 if (!isset($_SESSION['user'])) {
     header('Location: /login');
+    exit;
+}
+if (!is_admin($pdo)) {
+    echo 'Bu sayfayı görüntüleme yetkiniz yok.';
     exit;
 }
 load_theme_settings($pdo);

--- a/offer.php
+++ b/offer.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/auth.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -159,7 +160,9 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
                     <td class="text-center">
                         <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i class="bi bi-pencil"></i> Düzenle</a>
+                        <?php if (is_admin($pdo)): ?>
                         <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                        <?php endif; ?>
                         <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
@@ -188,7 +191,9 @@ include 'includes/header.php';
                         </p>
                         <div class="text-end">
                             <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i class="bi bi-pencil"></i> Düzenle</a>
+                            <?php if (is_admin($pdo)): ?>
                             <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                            <?php endif; ?>
                             <form method="post" action="offer" style="display:inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?php echo $q['id']; ?>">

--- a/product.php
+++ b/product.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/auth.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -177,7 +178,9 @@ $products = $stmt->fetchAll();
                             <td class="text-center">
                                 <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                     data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                <?php if (is_admin($pdo)): ?>
                                 <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                <?php endif; ?>
                                 <form method="post" action="product" style="display:inline-block"
                                     onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                     <input type="hidden" name="action" value="delete">
@@ -280,7 +283,9 @@ $products = $stmt->fetchAll();
                                 <div class="text-end">
                                     <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
                                         data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i> Düzenle</button>
+                                    <?php if (is_admin($pdo)): ?>
                                     <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                                    <?php endif; ?>
                                     <form method="post" action="product" style="display:inline-block"
                                         onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                         <input type="hidden" name="action" value="delete">


### PR DESCRIPTION
## Summary
- add `helpers/auth.php` with an `is_admin` helper
- block access to `log-list.php` for non-admin users
- hide log buttons in company, customer, product and offer pages for non-admins

## Testing
- `php -l helpers/auth.php`
- `php -l log-list.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_687225b29ca883288a1934ecf89570ab