### PR TITLE
Fix audit logging data

### DIFF
--- a/offer_form.php
+++ b/offer_form.php
@@ -58,7 +58,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guillotine']) && 
         ':remote_qty' => $_POST['remote_qty'],
         ':ral' => $_POST['ral_code']
     ]);
-    audit_log($pdo, 'guillotine_quotes', $pdo->lastInsertId(), 'create');
+    $newId = $pdo->lastInsertId();
+    $stmtData = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id=:id');
+    $stmtData->execute([':id' => $newId]);
+    $newData = $stmtData->fetch();
+    audit_log($pdo, 'guillotine_quotes', $newId, 'create', null, $newData);
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -82,13 +86,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_sliding']) && $id
         ':ral' => $_POST['ral_code'],
         ':locking' => $_POST['locking']
     ]);
-    audit_log($pdo, 'sliding_quotes', $pdo->lastInsertId(), 'create');
+    $newId = $pdo->lastInsertId();
+    $stmtData = $pdo->prepare('SELECT * FROM sliding_quotes WHERE id=:id');
+    $stmtData->execute([':id' => $newId]);
+    $newData = $stmtData->fetch();
+    audit_log($pdo, 'sliding_quotes', $newId, 'create', null, $newData);
     header('Location: offer_form?id=' . $id);
     exit;
 }
 
 // Handle editing guillotine quotes
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) && $id) {
+    $stmtOld = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id=:gid');
+    $stmtOld->execute([':gid' => $_POST['gid']]);
+    $oldData = $stmtOld->fetch();
+
     $stmt = $pdo->prepare(
         "UPDATE guillotine_quotes SET width_mm=:width, height_mm=:height, system_qty=:qty, glass_type=:glass, glass_color=:color, motor_system=:motor, remote_qty=:remote_qty, ral_code=:ral WHERE id=:gid AND master_quote_id=:master"
     );
@@ -104,25 +116,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) &&
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'update');
+    $stmtNew = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id=:gid');
+    $stmtNew->execute([':gid' => $_POST['gid']]);
+    $newData = $stmtNew->fetch();
+    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'update', $oldData, $newData);
     header('Location: offer_form?id=' . $id);
     exit;
 }
 
 // Handle deleting guillotine quotes
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_guillotine']) && $id) {
+    $stmtOld = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id=:gid');
+    $stmtOld->execute([':gid' => $_POST['gid']]);
+    $oldData = $stmtOld->fetch();
+
     $stmt = $pdo->prepare("DELETE FROM guillotine_quotes WHERE id=:gid AND master_quote_id=:master");
     $stmt->execute([
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'delete');
+    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'delete', $oldData, null);
     header('Location: offer_form?id=' . $id);
     exit;
 }
 
 // Handle editing sliding quotes
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_sliding']) && $id) {
+    $stmtOld = $pdo->prepare('SELECT * FROM sliding_quotes WHERE id=:sid');
+    $stmtOld->execute([':sid' => $_POST['sid']]);
+    $oldData = $stmtOld->fetch();
+
     $stmt = $pdo->prepare(
         "UPDATE sliding_quotes SET system_type=:system, width_mm=:width, height_mm=:height, wing_type=:wing, fastening_type=:fastening, glass_type=:glass, glass_color=:color, system_qty=:qty, ral_code=:ral, locking=:locking WHERE id=:sid AND master_quote_id=:master"
     );
@@ -140,19 +163,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_sliding']) && $i
         ':sid' => $_POST['sid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'update');
+    $stmtNew = $pdo->prepare('SELECT * FROM sliding_quotes WHERE id=:sid');
+    $stmtNew->execute([':sid' => $_POST['sid']]);
+    $newData = $stmtNew->fetch();
+    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'update', $oldData, $newData);
     header('Location: offer_form?id=' . $id);
     exit;
 }
 
 // Handle deleting sliding quotes
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_sliding']) && $id) {
+    $stmtOld = $pdo->prepare('SELECT * FROM sliding_quotes WHERE id=:sid');
+    $stmtOld->execute([':sid' => $_POST['sid']]);
+    $oldData = $stmtOld->fetch();
+
     $stmt = $pdo->prepare("DELETE FROM sliding_quotes WHERE id=:sid AND master_quote_id=:master");
     $stmt->execute([
         ':sid' => $_POST['sid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'delete');
+    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'delete', $oldData, null);
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -170,22 +200,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
     ];
 
     if ($id) {
+        $stmtOld = $pdo->prepare('SELECT * FROM master_quotes WHERE id=:id');
+        $stmtOld->execute([':id' => $id]);
+        $oldData = $stmtOld->fetch();
+
         $data[':id'] = $id;
         $stmt = $pdo->prepare(
             "UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id"
         );
+        $stmt->execute($data);
+        $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id=:id');
+        $stmtNew->execute([':id' => $id]);
+        $newData = $stmtNew->fetch();
+        audit_log($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
     } else {
         $data[':prepared'] = $_SESSION['user']['id'] ?? null;
         $stmt = $pdo->prepare(
             "INSERT INTO master_quotes (company_id, contact_id, quote_date, prepared_by, delivery_term, payment_method, payment_due, quote_validity, maturity) VALUES (:company, :contact, :date, :prepared, :delivery, :method, :due, :validity, :maturity)"
         );
-    }
-
-    $stmt->execute($data);
-    if ($id) {
-        audit_log($pdo, 'master_quotes', $id, 'update');
-    } else {
-        audit_log($pdo, 'master_quotes', $pdo->lastInsertId(), 'create');
+        $stmt->execute($data);
+        $newId = $pdo->lastInsertId();
+        $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id=:id');
+        $stmtNew->execute([':id' => $newId]);
+        $newData = $stmtNew->fetch();
+        audit_log($pdo, 'master_quotes', $newId, 'create', null, $newData);
     }
     header('Location: offer');
     exit;

--- a/register.php
+++ b/register.php
@@ -29,7 +29,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $hash = password_hash($password, PASSWORD_BCRYPT);
                 $insert = $pdo->prepare('INSERT INTO users (first_name, last_name, username, password_hash, email) VALUES (?, ?, ?, ?, ?)');
                 $insert->execute([$firstName, $lastName, $username, $hash, $email]);
-                audit_log($pdo, 'users', $pdo->lastInsertId(), 'create');
+                $newId = $pdo->lastInsertId();
+                $stmtNew = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+                $stmtNew->execute([$newId]);
+                $newData = $stmtNew->fetch();
+                audit_log($pdo, 'users', $newId, 'create', null, $newData);
                 $success = 'Kayıt başarılı. Giriş yapabilirsiniz.';
             }
         } catch (PDOException $e) {

--- a/settings.php
+++ b/settings.php
@@ -17,6 +17,10 @@ load_theme_settings($pdo);
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $theme = $_POST['theme'] ?? 'light';
     $color = $_POST['color'] ?? 'primary';
+    $oldData = [
+        'theme' => get_theme(),
+        'color' => get_color()
+    ];
     set_theme($theme);
     set_color($color);
 
@@ -44,7 +48,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':val'  => json_encode($color)
         ]);
         $pdo->commit();
-        audit_log($pdo, 'settings', $_SESSION['user']['id'], 'update');
+        $newData = [
+            'theme' => $theme,
+            'color' => $color
+        ];
+        audit_log($pdo, 'settings', $_SESSION['user']['id'], 'update', $oldData, $newData);
         $success = 'Ayarlar kaydedildi.';
     } catch (PDOException $e) {
         $pdo->rollBack();


### PR DESCRIPTION
## Summary
- track newly created user data in audit log
- keep old/new theme data for settings updates
- capture old and new values for quote operations

## Testing
- `php -l settings.php register.php offer_form.php`

------
https://chatgpt.com/codex/tasks/task_e_68749b45370483288161e30abc5d48eb