### PR TITLE
Implement logAction wrapper and use for audit logging

### DIFF
--- a/company.php
+++ b/company.php
@@ -29,7 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'companies', $newId, 'create', null, $newData);
+        logAction($pdo, 'companies', $newId, 'create', null, $newData);
         header('Location: company');
         exit;
     } elseif ($action === 'edit') {
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'companies', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
         header('Location: company');
         exit;
     } elseif ($action === 'delete') {
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM companies WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'companies', $id, 'delete', $oldData, null);
+        logAction($pdo, 'companies', $id, 'delete', $oldData, null);
         header('Location: company');
         exit;
     }

--- a/customers.php
+++ b/customers.php
@@ -37,7 +37,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'customers', $newId, 'create', null, $newData);
+        logAction($pdo, 'customers', $newId, 'create', null, $newData);
         header('Location: customers');
         exit;
     } elseif ($action === 'edit') {
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'customers', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
         header('Location: customers');
         exit;
     } elseif ($action === 'delete') {
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM customers WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'customers', $id, 'delete', $oldData, null);
+        logAction($pdo, 'customers', $id, 'delete', $oldData, null);
         header('Location: customers');
         exit;
     }

--- a/helpers/audit.php
+++ b/helpers/audit.php
@@ -55,3 +55,17 @@ function audit_log(PDO $pdo, string $table, $recordId, string $action, $oldValue
         // Do not interrupt application flow if audit logging fails
     }
 }
+
+/**
+ * Backwards compatible wrapper for audit_log.
+ * Accepts only standard action names create, update or delete.
+ */
+function logAction(PDO $pdo, string $table, $recordId, string $action, $oldValue = null, $newValue = null): void
+{
+    $allowed = ['create', 'update', 'delete'];
+    $action = strtolower($action);
+    if (!in_array($action, $allowed, true)) {
+        return;
+    }
+    audit_log($pdo, $table, $recordId, $action, $oldValue, $newValue);
+}

--- a/offer.php
+++ b/offer.php
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'master_quotes', $newId, 'create', null, $newData);
+        logAction($pdo, 'master_quotes', $newId, 'create', null, $newData);
         header('Location: offer');
         exit;
     } elseif ($action === 'edit') {
@@ -75,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
         header('Location: offer');
         exit;
     } elseif ($action === 'delete') {
@@ -86,7 +86,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM master_quotes WHERE id=:id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'master_quotes', $id, 'delete', $oldData, null);
+        logAction($pdo, 'master_quotes', $id, 'delete', $oldData, null);
         header('Location: offer');
         exit;
     }

--- a/product.php
+++ b/product.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM products WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'products', $newId, 'create', null, $newData);
+        logAction($pdo, 'products', $newId, 'create', null, $newData);
         header('Location: product');
         exit;
     } elseif ($action === 'edit') {
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'products', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'products', $id, 'update', $oldData, $newData);
         header('Location: product');
         exit;
     } elseif ($action === 'delete') {
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM products WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'products', $id, 'delete', $oldData, null);
+        logAction($pdo, 'products', $id, 'delete', $oldData, null);
         header('Location: product');
         exit;
     }

--- a/profile.php
+++ b/profile.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmtNew = $pdo->prepare('SELECT * FROM users WHERE id = ?');
                 $stmtNew->execute([$userId]);
                 $newData = $stmtNew->fetch();
-                audit_log($pdo, 'users', $userId, 'update', $oldData, $newData);
+                logAction($pdo, 'users', $userId, 'update', $oldData, $newData);
                 $_SESSION['user']['first_name'] = $firstName;
                 $_SESSION['user']['last_name']  = $lastName;
                 $_SESSION['user']['username']   = $username;


### PR DESCRIPTION
## Summary
- add `logAction()` wrapper to enforce standard action names
- use `logAction()` instead of `audit_log()` in CRUD pages

## Testing
- `php -l helpers/audit.php`
- `php -l company.php`
- `php -l customers.php`
- `php -l offer.php`
- `php -l product.php`
- `php -l profile.php`
- `php -l log-list.php`


------
https://chatgpt.com/codex/tasks/task_e_6874a5580a248328954ef7f166e2425f