### PR TITLE
Fix audit logging with array values

### DIFF
--- a/company.php
+++ b/company.php
@@ -29,7 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'companies', $newId, 'create', null, $newData);
+        logAction($pdo, 'companies', $newId, 'create', null, $newData);
         header('Location: company');
         exit;
     } elseif ($action === 'edit') {
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'companies', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
         header('Location: company');
         exit;
     } elseif ($action === 'delete') {
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM companies WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'companies', $id, 'delete', $oldData, null);
+        logAction($pdo, 'companies', $id, 'delete', $oldData, null);
         header('Location: company');
         exit;
     }

--- a/customers.php
+++ b/customers.php
@@ -37,7 +37,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'customers', $newId, 'create', null, $newData);
+        logAction($pdo, 'customers', $newId, 'create', null, $newData);
         header('Location: customers');
         exit;
     } elseif ($action === 'edit') {
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'customers', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
         header('Location: customers');
         exit;
     } elseif ($action === 'delete') {
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM customers WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'customers', $id, 'delete', $oldData, null);
+        logAction($pdo, 'customers', $id, 'delete', $oldData, null);
         header('Location: customers');
         exit;
     }

--- a/offer.php
+++ b/offer.php
@@ -51,7 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'master_quotes', $newId, 'create', null, $newData);
+        logAction($pdo, 'master_quotes', $newId, 'create', null, $newData);
         header('Location: offer');
         exit;
     } elseif ($action === 'edit') {
@@ -75,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
         header('Location: offer');
         exit;
     } elseif ($action === 'delete') {
@@ -86,7 +86,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM master_quotes WHERE id=:id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'master_quotes', $id, 'delete', $oldData, null);
+        logAction($pdo, 'master_quotes', $id, 'delete', $oldData, null);
         header('Location: offer');
         exit;
     }

--- a/offer_form.php
+++ b/offer_form.php
@@ -58,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guillotine']) && 
         ':remote_qty' => $_POST['remote_qty'],
         ':ral' => $_POST['ral_code']
     ]);
-    audit_log($pdo, 'guillotine_quotes', $pdo->lastInsertId(), 'create');
+    logAction($pdo, 'guillotine_quotes', $pdo->lastInsertId(), 'create');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_sliding']) && $id
         ':ral' => $_POST['ral_code'],
         ':locking' => $_POST['locking']
     ]);
-    audit_log($pdo, 'sliding_quotes', $pdo->lastInsertId(), 'create');
+    logAction($pdo, 'sliding_quotes', $pdo->lastInsertId(), 'create');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -104,7 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) &&
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'update');
+    logAction($pdo, 'guillotine_quotes', $_POST['gid'], 'update');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -116,7 +116,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_guillotine']) 
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'guillotine_quotes', $_POST['gid'], 'delete');
+    logAction($pdo, 'guillotine_quotes', $_POST['gid'], 'delete');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -140,7 +140,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_sliding']) && $i
         ':sid' => $_POST['sid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'update');
+    logAction($pdo, 'sliding_quotes', $_POST['sid'], 'update');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -152,7 +152,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_sliding']) && 
         ':sid' => $_POST['sid'],
         ':master' => $id
     ]);
-    audit_log($pdo, 'sliding_quotes', $_POST['sid'], 'delete');
+    logAction($pdo, 'sliding_quotes', $_POST['sid'], 'delete');
     header('Location: offer_form?id=' . $id);
     exit;
 }
@@ -183,9 +183,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
 
     $stmt->execute($data);
     if ($id) {
-        audit_log($pdo, 'master_quotes', $id, 'update');
+        logAction($pdo, 'master_quotes', $id, 'update');
     } else {
-        audit_log($pdo, 'master_quotes', $pdo->lastInsertId(), 'create');
+        logAction($pdo, 'master_quotes', $pdo->lastInsertId(), 'create');
     }
     header('Location: offer');
     exit;

--- a/product.php
+++ b/product.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtData = $pdo->prepare('SELECT * FROM products WHERE id = :id');
         $stmtData->execute([':id' => $newId]);
         $newData = $stmtData->fetch();
-        audit_log($pdo, 'products', $newId, 'create', null, $newData);
+        logAction($pdo, 'products', $newId, 'create', null, $newData);
         header('Location: product');
         exit;
     } elseif ($action === 'edit') {
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
         $stmtNew->execute([':id' => $id]);
         $newData = $stmtNew->fetch();
-        audit_log($pdo, 'products', $id, 'update', $oldData, $newData);
+        logAction($pdo, 'products', $id, 'update', $oldData, $newData);
         header('Location: product');
         exit;
     } elseif ($action === 'delete') {
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $stmt = $pdo->prepare("DELETE FROM products WHERE id = :id");
         $stmt->execute([':id' => $id]);
-        audit_log($pdo, 'products', $id, 'delete', $oldData, null);
+        logAction($pdo, 'products', $id, 'delete', $oldData, null);
         header('Location: product');
         exit;
     }

--- a/profile.php
+++ b/profile.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $stmtNew = $pdo->prepare('SELECT * FROM users WHERE id = ?');
                 $stmtNew->execute([$userId]);
                 $newData = $stmtNew->fetch();
-                audit_log($pdo, 'users', $userId, 'update', $oldData, $newData);
+                logAction($pdo, 'users', $userId, 'update', $oldData, $newData);
                 $_SESSION['user']['first_name'] = $firstName;
                 $_SESSION['user']['last_name']  = $lastName;
                 $_SESSION['user']['username']   = $username;

--- a/register.php
+++ b/register.php
@@ -29,7 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $hash = password_hash($password, PASSWORD_BCRYPT);
                 $insert = $pdo->prepare('INSERT INTO users (first_name, last_name, username, password_hash, email) VALUES (?, ?, ?, ?, ?)');
                 $insert->execute([$firstName, $lastName, $username, $hash, $email]);
-                audit_log($pdo, 'users', $pdo->lastInsertId(), 'create');
+                logAction($pdo, 'users', $pdo->lastInsertId(), 'create');
                 $success = 'Kayıt başarılı. Giriş yapabilirsiniz.';
             }
         } catch (PDOException $e) {

--- a/settings.php
+++ b/settings.php
@@ -44,7 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':val'  => json_encode($color)
         ]);
         $pdo->commit();
-        audit_log($pdo, 'settings', $_SESSION['user']['id'], 'update');
+        logAction($pdo, 'settings', $_SESSION['user']['id'], 'update');
         $success = 'Ayarlar kaydedildi.';
     } catch (PDOException $e) {
         $pdo->rollBack();


### PR DESCRIPTION
## Summary
- ensure old/new values are JSON encoded at start of `audit_log`
- add `logAction` helper to restrict allowed actions
- switch all calls to use `logAction`

## Testing
- `php -l helpers/audit.php`
- `php -l customers.php`
- `php -l profile.php`
- `php -l offer_form.php`
- `php -l product.php`
- `php -l register.php`
- `php -l company.php`
- `php -l offer.php`
- `php -l settings.php`


------
https://chatgpt.com/codex/tasks/task_e_6874aa8ce420832885eff48784b513a5