### PR TITLE
Improve log viewer

### DIFF
--- a/log-list.php
+++ b/log-list.php
@@ -3,7 +3,7 @@ require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/auth.php';
 
-// Start session and ensure user is authenticated
+// Start session and ensure authentication
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -12,84 +12,46 @@ if (!isset($_SESSION['user'])) {
     exit;
 }
 
-// Load theme/color preferences
+// Load user theme preferences
 load_theme_settings($pdo);
 
 /**
- * Sanitize GET parameter value.
+ * Sanitize query parameter
  */
 function get_param(string $key): ?string
 {
     return isset($_GET[$key]) ? trim($_GET[$key]) : null;
 }
 
-$recordId  = get_param('record_id');
-$tableName = get_param('table_name');
+// Retrieve and sanitize filter values
+$username = filter_var(get_param('username'), FILTER_SANITIZE_STRING) ?? '';
+$sort     = strtolower(get_param('sort') ?? 'desc');
+$sort     = $sort === 'asc' ? 'ASC' : 'DESC';
 
-if (!$recordId || !$tableName) {
-    // Missing parameters
-    ?>
-<!DOCTYPE html>
-<html lang="tr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Log Kayıtları</title>
-    <link href="<?php echo theme_css(); ?>" rel="stylesheet">
-</head>
-<body class="bg-light">
-<?php include 'includes/header.php'; ?>
-<div class="container py-4">
-    <div class="alert alert-warning">Kayıt bilgisi bulunamadı.</div>
-</div>
-</body>
-</html>
-<?php
-    exit;
+// Build SQL query
+$sql = "SELECT al.id, al.user_id, u.username, al.action_time, al.table_name,
+               al.record_id, al.column_name, al.old_value, al.new_value,
+               al.description, al.action_id, ac.name AS action_name
+        FROM audit_logs al
+        LEFT JOIN users u   ON al.user_id = u.id
+        LEFT JOIN actions ac ON al.action_id = ac.id";
+$params = [];
+$conditions = [];
+
+if ($username !== '') {
+    $conditions[] = 'u.username LIKE :username';
+    $params[':username'] = "%{$username}%";
 }
 
-$recordId  = (int)$recordId; // sanitize numeric
-$tableName = htmlspecialchars($tableName, ENT_QUOTES, 'UTF-8');
-
-/**
- * Fetch logs for a specific record.
- */
-function fetch_logs(PDO $pdo, int $recordId, string $tableName): array
-{
-    $sql = "SELECT al.id, al.action_time, al.old_value, al.new_value, al.description,
-                   u.username, ac.name AS action_name
-            FROM audit_logs al
-            LEFT JOIN users u ON al.user_id = u.id
-            LEFT JOIN actions ac ON al.action_id = ac.id
-            WHERE al.record_id = :record_id AND al.table_name = :table_name
-            ORDER BY al.action_time DESC";
-    $stmt = $pdo->prepare($sql);
-    $stmt->execute([':record_id' => $recordId, ':table_name' => $tableName]);
-    return $stmt->fetchAll();
+if ($conditions) {
+    $sql .= ' WHERE ' . implode(' AND ', $conditions);
 }
 
-/**
- * Compare JSON values and return changed fields.
- */
-function diff_values(string $oldJson, string $newJson): array
-{
-    $old = json_decode($oldJson, true) ?: [];
-    $new = json_decode($newJson, true) ?: [];
-    $diff = [];
-    foreach ($new as $key => $value) {
-        $oldValue = $old[$key] ?? null;
-        if ($oldValue !== $value) {
-            $diff[] = [
-                'field' => $key,
-                'old'   => $oldValue,
-                'new'   => $value,
-            ];
-        }
-    }
-    return $diff;
-}
+$sql .= " ORDER BY al.action_time $sort";
 
-$logs = fetch_logs($pdo, $recordId, $tableName);
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$logs = $stmt->fetchAll();
 ?>
 <!DOCTYPE html>
 <html lang="tr">
@@ -104,43 +66,58 @@ $logs = fetch_logs($pdo, $recordId, $tableName);
 <?php include 'includes/header.php'; ?>
 <div class="container py-4">
     <h2 class="mb-4">Log Kayıtları</h2>
-    <?php if (empty($logs)): ?>
-        <div class="alert alert-info">Bu kayıt için log bulunamadı.</div>
-    <?php endif; ?>
-    <?php foreach ($logs as $log): ?>
-        <?php $changes = diff_values($log['old_value'], $log['new_value']); ?>
-        <div class="card mb-3">
-            <div class="card-header d-flex justify-content-between align-items-center">
-                <span><?php echo htmlspecialchars($log['action_time']); ?></span>
-                <button class="btn btn-sm btn-outline-<?php echo get_color(); ?>" type="button" data-bs-toggle="collapse" data-bs-target="#log<?php echo $log['id']; ?>" aria-expanded="false" aria-controls="log<?php echo $log['id']; ?>">
-                    Detayları Gör
-                </button>
-            </div>
-            <div class="card-body">
-                <p class="mb-1">Kullanıcı: <strong><?php echo htmlspecialchars($log['username']); ?></strong></p>
-                <p class="mb-1">İşlem: <strong><?php echo htmlspecialchars($log['action_name']); ?></strong></p>
-                <p class="mb-2"><?php echo htmlspecialchars($log['description']); ?></p>
-                <div class="collapse" id="log<?php echo $log['id']; ?>">
-                    <?php if ($changes): ?>
-                        <ul class="list-group">
-                            <?php foreach ($changes as $change): ?>
-                                <li class="list-group-item d-flex justify-content-between align-items-start">
-                                    <div><i class="bi bi-arrow-right-circle-fill text-<?php echo get_color(); ?> me-2"></i><?php echo htmlspecialchars($change['field']); ?></div>
-                                    <div>
-                                        <span class="text-muted me-1"><?php echo htmlspecialchars(var_export($change['old'], true)); ?></span>
-                                        <i class="bi bi-arrow-right"></i>
-                                        <span class="fw-bold ms-1"><?php echo htmlspecialchars(var_export($change['new'], true)); ?></span>
-                                    </div>
-                                </li>
-                            <?php endforeach; ?>
-                        </ul>
-                    <?php else: ?>
-                        <div class="text-muted">Değişiklik yok</div>
-                    <?php endif; ?>
-                </div>
-            </div>
+    <form method="get" class="row gy-2 gx-3 align-items-center mb-4">
+        <div class="col-sm-4">
+            <input type="text" class="form-control" name="username" placeholder="Kullanıcı ara" value="<?php echo htmlspecialchars($username); ?>">
         </div>
-    <?php endforeach; ?>
+        <div class="col-sm-3">
+            <select name="sort" class="form-select">
+                <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Yeni Tarih</option>
+                <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>Eski Tarih</option>
+            </select>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-<?php echo get_color(); ?>">Filtrele</button>
+        </div>
+    </form>
+    <?php if (empty($logs)): ?>
+        <div class="alert alert-info">Kayıt bulunamadı.</div>
+    <?php else: ?>
+    <div class="table-responsive">
+        <table class="table table-striped table-bordered">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Kullanıcı</th>
+                    <th>Tarih</th>
+                    <th>Tablo</th>
+                    <th>Kayıt ID</th>
+                    <th>Sütun</th>
+                    <th>Eski Değer</th>
+                    <th>Yeni Değer</th>
+                    <th>Açıklama</th>
+                    <th>İşlem</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($logs as $log): ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($log['id']); ?></td>
+                    <td><?php echo htmlspecialchars($log['username'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($log['action_time']); ?></td>
+                    <td><?php echo htmlspecialchars($log['table_name']); ?></td>
+                    <td><?php echo htmlspecialchars($log['record_id']); ?></td>
+                    <td><?php echo htmlspecialchars($log['column_name']); ?></td>
+                    <td><?php echo htmlspecialchars($log['old_value']); ?></td>
+                    <td><?php echo htmlspecialchars($log['new_value']); ?></td>
+                    <td><?php echo htmlspecialchars($log['description']); ?></td>
+                    <td><?php echo htmlspecialchars($log['action_name']); ?></td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rework log-list page to support user filtering and sort order
- display audit log records in a bootstrap table

## Testing
- `php -l log-list.php`

------
https://chatgpt.com/codex/tasks/task_e_6874c20d265c8328beecb5588b39ae78