### PR TITLE
Add settings sidebar and notifications

### DIFF
--- a/helpers/notifications.php
+++ b/helpers/notifications.php
@@ -1,0 +1,33 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function set_notification_pref(bool $enabled): void
+{
+    $_SESSION['notify_email'] = $enabled;
+}
+
+function get_notification_pref(): bool
+{
+    return $_SESSION['notify_email'] ?? true;
+}
+
+function load_notification_settings(PDO $pdo): void
+{
+    if (!isset($_SESSION['user']['id'])) {
+        return;
+    }
+    $query = "SELECT value FROM settings WHERE user_id = ? AND `key` = 'notify_email'";
+    try {
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([$_SESSION['user']['id']]);
+        $val = $stmt->fetchColumn();
+        if ($val !== false && !isset($_SESSION['notify_email'])) {
+            set_notification_pref((bool) json_decode($val, true));
+        }
+    } catch (PDOException $e) {
+        // ignore errors
+    }
+}
+?>

--- a/settings.php
+++ b/settings.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/notifications.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -13,12 +14,15 @@ if (!isset($_SESSION['user'])) {
 $errors = [];
 $success = '';
 load_theme_settings($pdo);
+load_notification_settings($pdo);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $theme = $_POST['theme'] ?? 'light';
     $color = $_POST['color'] ?? 'primary';
+    $notify = isset($_POST['notify_email']) ? (bool)$_POST['notify_email'] : true;
     set_theme($theme);
     set_color($color);
+    set_notification_pref($notify);
 
     try {
         $pdo->beginTransaction();
@@ -43,6 +47,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':user' => $_SESSION['user']['id'],
             ':val'  => json_encode($color)
         ]);
+        // Save notification preference
+        $stmt = $pdo->prepare(
+            "INSERT INTO settings (user_id, `key`, value) " .
+            "VALUES (:user, 'notify_email', :val) " .
+            "ON DUPLICATE KEY UPDATE value = VALUES(value)"
+        );
+        $stmt->execute([
+            ':user' => $_SESSION['user']['id'],
+            ':val'  => json_encode($notify)
+        ]);
         $pdo->commit();
         logAction($pdo, 'settings', $_SESSION['user']['id'], 'update');
         $success = 'Ayarlar kaydedildi.';
@@ -60,25 +74,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <title>Ayarlar</title>
     <link href="<?php echo theme_css(); ?>" rel="stylesheet">
 </head>
-<body class="bg-light">
+<body class="bg-light" data-bs-spy="scroll" data-bs-target="#settingsMenu" data-bs-offset="100" tabindex="0">
     <?php include 'includes/header.php'; ?>
     <div class="container py-4">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">Tema Ayarları</h5>
-                        <?php if ($success): ?>
-                            <div class="alert alert-success">
-                                <?php echo htmlspecialchars($success); ?>
-                            </div>
-                        <?php endif; ?>
-                        <?php if ($errors): ?>
-                            <div class="alert alert-danger">
-                                <?php echo implode('<br>', array_map('htmlspecialchars', $errors)); ?>
-                            </div>
-                        <?php endif; ?>
-                        <form method="post">
+        <div class="row">
+            <nav id="settingsMenu" class="col-md-3 mb-4">
+                <ul class="nav flex-column position-sticky" style="top:2rem">
+                    <li class="nav-item"><a class="nav-link active" href="#theme-settings">Tema Ayarları</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#notification-settings">Bildirim Ayarları</a></li>
+                </ul>
+            </nav>
+            <div class="col-md-9">
+                <?php if ($success): ?>
+                    <div class="alert alert-success">
+                        <?php echo htmlspecialchars($success); ?>
+                    </div>
+                <?php endif; ?>
+                <?php if ($errors): ?>
+                    <div class="alert alert-danger">
+                        <?php echo implode('<br>', array_map('htmlspecialchars', $errors)); ?>
+                    </div>
+                <?php endif; ?>
+                <form method="post">
+                    <section id="theme-settings" class="card mb-5">
+                        <div class="card-body">
+                            <h5 class="card-title">Tema Ayarları</h5>
                             <div class="mb-3">
                                 <label class="form-label" for="theme">Tema</label>
                                 <select id="theme" name="theme" class="form-select">
@@ -98,10 +118,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     ?>
                                 </select>
                             </div>
-                            <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                        </form>
-                    </div>
-                </div>
+                        </div>
+                    </section>
+                    <section id="notification-settings" class="card mb-5">
+                        <div class="card-body">
+                            <h5 class="card-title">Bildirim Ayarları</h5>
+                            <div class="mb-3">
+                                <label class="form-label" for="notify_email">E-posta Bildirimleri</label>
+                                <select id="notify_email" name="notify_email" class="form-select">
+                                    <option value="1" <?php echo get_notification_pref() ? 'selected' : ''; ?>>Açık</option>
+                                    <option value="0" <?php echo !get_notification_pref() ? 'selected' : ''; ?>>Kapalı</option>
+                                </select>
+                            </div>
+                        </div>
+                    </section>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce notification preference helper
- extend settings page with sidebar and email notification option

## Testing
- `php -l helpers/notifications.php`
- `php -l settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68775864d6f48328bfb0250941e8d84f