### PR TITLE
Fix tFPDF magic quotes error

### DIFF
--- a/tFPDF.php
+++ b/tFPDF.php
@@ -1256,9 +1256,12 @@ function _dochecks()
 	// Check mbstring overloading
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
-	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+        // Ensure runtime magic quotes are disabled
+        if(function_exists('get_magic_quotes_runtime') && get_magic_quotes_runtime())
+        {
+                if(function_exists('set_magic_quotes_runtime'))
+                        @set_magic_quotes_runtime(0);
+        }
 }
 
 function _getfontpath()


### PR DESCRIPTION
## Summary
- avoid calling deprecated `get_magic_quotes_runtime` and `set_magic_quotes_runtime`

## Testing
- `php -l tFPDF.php`

------
https://chatgpt.com/codex/tasks/task_e_68777d6936708328bd57bedd868cb763