### PR TITLE
Show product images in PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GST Project
 
-This project is a PHP-based quoting system. Product images are stored directly in the database using a BLOB `image_data` column with its MIME type in `image_type`. Images are only shown on the optimization page using base64 data URLs.
+This project is a PHP-based quoting system. Product images are stored directly in the database using a BLOB `image_data` column with its MIME type in `image_type`. Images are displayed on both the optimization and PDF pages using base64 data URLs.
 
 See `image_upload_example.php` for a minimal example of handling an image upload and saving the binary data.

--- a/pdf.php
+++ b/pdf.php
@@ -138,11 +138,16 @@ function compute_optimization(PDO $pdo, float $width, float $height, int $quanti
 
     $total_cost = 0;
     foreach ($results as &$row) {
-        $stmt = $pdo->prepare('SELECT unit, measure_value, unit_price, category FROM products WHERE name = ? LIMIT 1');
+        $stmt = $pdo->prepare('SELECT unit, measure_value, unit_price, category, image_data, image_type FROM products WHERE name = ? LIMIT 1');
         $stmt->execute([$row['name']]);
         $product = $stmt->fetch();
         $row['cost'] = null;
         $row['category'] = $nameCategoryMap[$row['name']] ?? ($product['category'] ?? 'Diğer');
+        if (!empty($product['image_data'])) {
+            $row['image_src'] = 'data:' . $product['image_type'] . ';base64,' . base64_encode($product['image_data']);
+        } else {
+            $row['image_src'] = null;
+        }
         if ($product) {
             $count = is_numeric($row['count']) ? (float) $row['count'] : 0;
             $length = is_numeric($row['length']) ? (float) $row['length'] : 0;
@@ -238,7 +243,12 @@ function compute_optimization(PDO $pdo, float $width, float $height, int $quanti
                         <?php $len = is_numeric($row['length']) ? round($row['length']) : $row['length']; ?>
                         <?php $cost = is_null($row['cost']) ? '-' : round($row['cost']); ?>
                         <tr>
-                            <td><?php echo $row['name']; ?></td>
+                            <td>
+                                <?php if (!empty($row['image_src'])): ?>
+                                    <img src="<?php echo htmlspecialchars($row['image_src']); ?>" alt="" style="max-width:40px" class="me-2">
+                                <?php endif; ?>
+                                <?php echo htmlspecialchars($row['name']); ?>
+                            </td>
                             <td><?php echo $len; ?></td>
                             <td><?php echo $row['count']; ?></td>
                             <td><?php echo $cost; ?></td>


### PR DESCRIPTION
## Summary
- fetch product images when computing quote details
- display associated images in pdf.php rows
- update README to note images also appear in PDF

## Testing
- `php -l pdf.php`

------
https://chatgpt.com/codex/tasks/task_e_68789d5458d0832899d95fd9e2456f9c