### PR TITLE
Improve mobile card layout for listings

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,11 @@
+@media (max-width: 767.98px) {
+    .view-toggle {
+        display: none !important;
+    }
+    .responsive-table {
+        display: none;
+    }
+}
+.cards-row .card {
+    margin-bottom: 1rem;
+}

--- a/company.php
+++ b/company.php
@@ -113,7 +113,7 @@ $companies = $stmt->fetchAll();
                 <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                     data-bs-target="#addModal">Firma
                     Ekle</button>
-                <div class="btn-group ms-2" role="group">
+                <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
                     <a href="<?php echo $listUrl; ?>"
                         class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i
                             class="bi bi-list"></i></a>
@@ -125,7 +125,7 @@ $companies = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped">
+            <table class="table table-bordered table-striped responsive-table">
                 <thead>
                     <tr>
                         <th>Ad</th>
@@ -208,9 +208,9 @@ $companies = $stmt->fetchAll();
                 </tbody>
             </table>
         <?php else: ?>
-            <div class="row">
+            <div class="row g-3 cards-row">
                 <?php foreach ($companies as $company): ?>
-                    <div class="col-md-4">
+                    <div class="col-12 col-md-4">
                         <div class="card mb-3">
                             <div class="card-body">
                                 <h5 class="card-title"><?php echo htmlspecialchars($company['name']); ?></h5>

--- a/company.php
+++ b/company.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/device.php';
 // Log create, update and delete actions
 require_once 'helpers/audit.php';
 require_once 'helpers/auth.php';
@@ -68,7 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $search = $_GET['search'] ?? '';
 $sort = (isset($_GET['sort']) && $_GET['sort'] === 'desc') ? 'DESC' : 'ASC';
-$view = $_GET['view'] ?? 'list';
+$view = $_GET['view'] ?? (is_mobile() ? 'card' : 'list');
 
 $p = $_GET;
 $p['view'] = 'list';

--- a/customers.php
+++ b/customers.php
@@ -139,7 +139,7 @@ $customers = $stmt->fetchAll();
                 <?php else: ?>
                     <a href="company" class="btn btn-<?php echo get_color(); ?>">Firma Ekle</a>
                 <?php endif; ?>
-                <div class="btn-group ms-2" role="group">
+                <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
                     <a href="<?php echo $listUrl; ?>"
                         class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i
                             class="bi bi-list"></i></a>
@@ -151,7 +151,7 @@ $customers = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped">
+            <table class="table table-bordered table-striped responsive-table">
                 <thead>
                     <tr>
                         <th>İsim</th>
@@ -264,9 +264,9 @@ $customers = $stmt->fetchAll();
                 </tbody>
             </table>
         <?php else: ?>
-            <div class="row">
+            <div class="row g-3 cards-row">
                 <?php foreach ($customers as $customer): ?>
-                    <div class="col-md-4">
+                    <div class="col-12 col-md-4">
                         <div class="card mb-3">
                             <div class="card-body">
                                 <h5 class="card-title">

--- a/customers.php
+++ b/customers.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/device.php';
 // Log create, update and delete actions
 require_once 'helpers/audit.php';
 require_once 'helpers/auth.php';
@@ -79,7 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $search = $_GET['search'] ?? '';
 $sort = (isset($_GET['sort']) && $_GET['sort'] === 'desc') ? 'DESC' : 'ASC';
-$view = $_GET['view'] ?? 'list';
+$view = $_GET['view'] ?? (is_mobile() ? 'card' : 'list');
 
 $params = $_GET;
 $params['view'] = 'list';

--- a/helpers/device.php
+++ b/helpers/device.php
@@ -1,0 +1,6 @@
+<?php
+function is_mobile(): bool
+{
+    $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+    return preg_match('/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i', $ua) === 1;
+}

--- a/includes/header.php
+++ b/includes/header.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../helpers/theme.php';
 ?>
 <link href="<?php echo theme_css(); ?>" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+<link rel="stylesheet" href="/assets/css/style.css">
 <nav
     class="navbar navbar-expand-lg <?php echo get_theme() === 'dark' ? 'navbar-dark bg-dark' : 'navbar-light bg-light'; ?>">
     <div class="container">

--- a/offer.php
+++ b/offer.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/device.php';
 // Log create, update and delete actions
 require_once 'helpers/audit.php';
 require_once 'helpers/auth.php';
@@ -107,7 +108,7 @@ $stmt->execute([
     ':search2' => "%$search%"
 ]);
 $quotes = $stmt->fetchAll();
-$view = $_GET['view'] ?? 'list';
+$view = $_GET['view'] ?? (is_mobile() ? 'card' : 'list');
 
 $p = $_GET;
 $p['view'] = 'list';

--- a/offer.php
+++ b/offer.php
@@ -143,7 +143,7 @@ include 'includes/header.php';
             <?php if ($canAdd): ?>
                 <a href="offer_form" class="btn btn-<?php echo get_color(); ?>">Teklif Ekle</a>
             <?php endif; ?>
-            <div class="btn-group ms-2" role="group">
+            <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
                 <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
                 <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
             </div>
@@ -151,7 +151,7 @@ include 'includes/header.php';
     </div>
 
     <?php if ($view === 'list'): ?>
-    <table class="table table-bordered table-striped">
+    <table class="table table-bordered table-striped responsive-table">
         <thead>
             <tr>
                 <th>Firma</th>
@@ -195,9 +195,9 @@ include 'includes/header.php';
         </tbody>
     </table>
     <?php else: ?>
-    <div class="row">
+    <div class="row g-3 cards-row">
         <?php foreach ($quotes as $q): ?>
-            <div class="col-md-4">
+            <div class="col-12 col-md-4">
                 <div class="card mb-3">
                     <div class="card-body">
                         <h5 class="card-title"><?php echo htmlspecialchars($q['company_name']); ?></h5>

--- a/product.php
+++ b/product.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/device.php';
 // Log create, update and delete actions
 require_once 'helpers/audit.php';
 require_once 'helpers/auth.php';
@@ -107,7 +108,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $search = $_GET['search'] ?? '';
 $sort = (isset($_GET['sort']) && $_GET['sort'] === 'desc') ? 'DESC' : 'ASC';
 $categoryFilter = $_GET['category'] ?? '';
-$view = $_GET['view'] ?? 'list';
+$view = $_GET['view'] ?? (is_mobile() ? 'card' : 'list');
 
 $paramList = $_GET;
 $paramList['view'] = 'list';

--- a/product.php
+++ b/product.php
@@ -175,7 +175,7 @@ $products = $stmt->fetchAll();
                 <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
                     data-bs-target="#addModal">Ürün
                     Ekle</button>
-                <div class="btn-group ms-2" role="group">
+                <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
                     <a href="<?php echo $listUrl; ?>"
                         class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i
                             class="bi bi-list"></i></a>
@@ -188,7 +188,7 @@ $products = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped">
+            <table class="table table-bordered table-striped responsive-table">
                 <thead>
                     <tr>
                         <th>Ad</th>
@@ -305,9 +305,9 @@ $products = $stmt->fetchAll();
                 </tbody>
             </table>
         <?php else: ?>
-            <div class="row">
+            <div class="row g-3 cards-row">
                 <?php foreach ($products as $product): ?>
-                    <div class="col-md-4">
+                    <div class="col-12 col-md-4">
                         <div class="card mb-3">
                             <div class="card-body">
                                 <h5 class="card-title"><?php echo htmlspecialchars($product['name']); ?>


### PR DESCRIPTION
## Summary
- add a global stylesheet with mobile layout rules
- include the stylesheet in the header
- hide view toggles on small screens and switch card grid classes
- ensure tables hide on mobile

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`

------
https://chatgpt.com/codex/tasks/task_e_6878c78d70588328b423c429c68cb666