### PR TITLE
Add change detection before updates

### DIFF
--- a/company.php
+++ b/company.php
@@ -133,162 +133,166 @@ $companies = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped responsive-table">
-                <thead>
-                    <tr>
-                        <th>Ad</th>
-                        <th>Telefon</th>
-                        <th>Adres</th>
-                        <th>E-posta</th>
-                        <th class="text-center actions-col">İşlemler</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($companies as $company): ?>
-                        <tr>
-                            <td><?php echo htmlspecialchars($company['name']); ?></td>
-                            <td><?php echo htmlspecialchars($company['phone']); ?></td>
-                            <td><?php echo htmlspecialchars($company['address']); ?></td>
-                            <td><?php echo htmlspecialchars($company['email']); ?></td>
-                            <td class="text-center">
-                                <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                <?php if (is_admin($pdo)): ?>
-                                <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                <?php endif; ?>
-                                <form method="post" action="company" class="d-inline-block"
-                                    onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                    <input type="hidden" name="action" value="delete">
-                                    <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                </form>
-                            </td>
-                        </tr>
-
-                        <!-- Edit Modal -->
-                        <div class="modal fade" id="editModal<?php echo $company['id']; ?>" tabindex="-1" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Firma Düzenle</h5>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                            aria-label="Close"></button>
-                                    </div>
-                                    <form method="post" action="company">
-                                        <div class="modal-body">
-                                            <input type="hidden" name="action" value="edit">
-                                            <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                            <div class="mb-3">
-                                                <label class="form-label">Ad</label>
-                                                <input type="text" name="name"
-                                                    value="<?php echo htmlspecialchars($company['name']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Telefon</label>
-                                                <input type="text" name="phone"
-                                                    value="<?php echo htmlspecialchars($company['phone']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Adres</label>
-                                                <input type="text" name="address"
-                                                    value="<?php echo htmlspecialchars($company['address']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">E-posta</label>
-                                                <input type="email" name="email"
-                                                    value="<?php echo htmlspecialchars($company['email']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="button" class="btn btn-secondary"
-                                                data-bs-dismiss="modal">Kapat</button>
-                                            <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php else: ?>
-            <div class="row g-3 cards-row">
+        <table class="table table-bordered table-striped responsive-table">
+            <thead>
+                <tr>
+                    <th>Ad</th>
+                    <th>Telefon</th>
+                    <th>Adres</th>
+                    <th>E-posta</th>
+                    <th class="text-center actions-col">İşlemler</th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php foreach ($companies as $company): ?>
-                    <div class="col-12 col-md-4">
-                        <div class="card mb-3">
-                            <div class="card-body">
-                                <h5 class="card-title"><?php echo htmlspecialchars($company['name']); ?></h5>
-                                <p class="card-text">
-                                    Telefon: <?php echo htmlspecialchars($company['phone']); ?><br>
-                                    Adres: <?php echo htmlspecialchars($company['address']); ?><br>
-                                    E-posta: <?php echo htmlspecialchars($company['email']); ?>
-                                </p>
-                                <div class="text-end">
-                                    <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $company['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                    <?php if (is_admin($pdo)): ?>
-                                    <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                    <?php endif; ?>
-                                    <form method="post" action="company" class="d-inline-block"
-                                        onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                        <input type="hidden" name="action" value="delete">
-                                        <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <tr>
+                    <td><?php echo htmlspecialchars($company['name']); ?></td>
+                    <td><?php echo htmlspecialchars($company['phone']); ?></td>
+                    <td><?php echo htmlspecialchars($company['address']); ?></td>
+                    <td><?php echo htmlspecialchars($company['email']); ?></td>
+                    <td class="text-center">
+                        <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                            data-bs-target="#editModal<?php echo $company['id']; ?>"><i
+                                class="bi bi-pencil"></i></button>
+                        <?php if (is_admin($pdo)): ?>
+                        <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>"
+                            class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                        <?php endif; ?>
+                        <form method="post" action="company" class="d-inline-block"
+                            onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
+                            <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                        </form>
+                    </td>
+                </tr>
 
-                    <!-- Edit Modal -->
-                    <div class="modal fade" id="editModal<?php echo $company['id']; ?>" tabindex="-1" aria-hidden="true">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Firma Düzenle</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <form method="post" action="company">
-                                    <div class="modal-body">
-                                        <input type="hidden" name="action" value="edit">
-                                        <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
-                                        <div class="mb-3">
-                                            <label class="form-label">Ad</label>
-                                            <input type="text" name="name"
-                                                value="<?php echo htmlspecialchars($company['name']); ?>" class="form-control"
-                                                required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Telefon</label>
-                                            <input type="text" name="phone"
-                                                value="<?php echo htmlspecialchars($company['phone']); ?>" class="form-control">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Adres</label>
-                                            <input type="text" name="address"
-                                                value="<?php echo htmlspecialchars($company['address']); ?>"
-                                                class="form-control">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">E-posta</label>
-                                            <input type="email" name="email"
-                                                value="<?php echo htmlspecialchars($company['email']); ?>" class="form-control">
-                                        </div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                        <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                    </div>
-                                </form>
+                <!-- Edit Modal -->
+                <div class="modal fade" id="editModal<?php echo $company['id']; ?>" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Firma Düzenle</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                    aria-label="Close"></button>
                             </div>
+                            <form method="post" action="company">
+                                <div class="modal-body">
+                                    <input type="hidden" name="action" value="edit">
+                                    <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
+                                    <div class="mb-3">
+                                        <label class="form-label">Ad</label>
+                                        <input type="text" name="name"
+                                            value="<?php echo htmlspecialchars($company['name']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Telefon</label>
+                                        <input type="text" name="phone"
+                                            value="<?php echo htmlspecialchars($company['phone']); ?>"
+                                            class="form-control">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Adres</label>
+                                        <input type="text" name="address"
+                                            value="<?php echo htmlspecialchars($company['address']); ?>"
+                                            class="form-control">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">E-posta</label>
+                                        <input type="email" name="email"
+                                            value="<?php echo htmlspecialchars($company['email']); ?>"
+                                            class="form-control">
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary"
+                                        data-bs-dismiss="modal">Kapat</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                                </div>
+                            </form>
                         </div>
                     </div>
+                </div>
                 <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php else: ?>
+        <div class="row g-3 cards-row">
+            <?php foreach ($companies as $company): ?>
+            <div class="col-12 col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title"><?php echo htmlspecialchars($company['name']); ?></h5>
+                        <p class="card-text">
+                            Telefon: <?php echo htmlspecialchars($company['phone']); ?><br>
+                            Adres: <?php echo htmlspecialchars($company['address']); ?><br>
+                            E-posta: <?php echo htmlspecialchars($company['email']); ?>
+                        </p>
+                        <div class="text-end">
+                            <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                                data-bs-target="#editModal<?php echo $company['id']; ?>"><i
+                                    class="bi bi-pencil"></i></button>
+                            <?php if (is_admin($pdo)): ?>
+                            <a href="log-list.php?table=companies&id=<?php echo $company['id']; ?>"
+                                class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                            <?php endif; ?>
+                            <form method="post" action="company" class="d-inline-block"
+                                onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
+                                <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </div>
+
+            <!-- Edit Modal -->
+            <div class="modal fade" id="editModal<?php echo $company['id']; ?>" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Firma Düzenle</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <form method="post" action="company">
+                            <div class="modal-body">
+                                <input type="hidden" name="action" value="edit">
+                                <input type="hidden" name="id" value="<?php echo $company['id']; ?>">
+                                <div class="mb-3">
+                                    <label class="form-label">Ad</label>
+                                    <input type="text" name="name"
+                                        value="<?php echo htmlspecialchars($company['name']); ?>" class="form-control"
+                                        required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Telefon</label>
+                                    <input type="text" name="phone"
+                                        value="<?php echo htmlspecialchars($company['phone']); ?>" class="form-control">
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Adres</label>
+                                    <input type="text" name="address"
+                                        value="<?php echo htmlspecialchars($company['address']); ?>"
+                                        class="form-control">
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">E-posta</label>
+                                    <input type="email" name="email"
+                                        value="<?php echo htmlspecialchars($company['email']); ?>" class="form-control">
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
         <?php endif; ?>
     </div>
     <!-- Filter Modal -->
@@ -310,7 +314,8 @@ $companies = $stmt->fetchAll();
                             <label class="form-label">Sıralama</label>
                             <select name="sort" class="form-select">
                                 <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
-                                <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                                <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya
+                                </option>
                             </select>
                         </div>
                     </div>

--- a/company.php
+++ b/company.php
@@ -39,18 +39,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE companies SET name = :name, phone = :phone, address = :address, email = :email WHERE id = :id");
-        $stmt->execute([
-            ':name' => $_POST['name'],
-            ':phone' => $_POST['phone'],
-            ':address' => $_POST['address'],
-            ':email' => $_POST['email'],
-            ':id' => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
+        $hasChanges = $oldData['name'] !== $_POST['name'] ||
+                      $oldData['phone'] !== $_POST['phone'] ||
+                      $oldData['address'] !== $_POST['address'] ||
+                      $oldData['email'] !== $_POST['email'];
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE companies SET name = :name, phone = :phone, address = :address, email = :email WHERE id = :id");
+            $stmt->execute([
+                ':name' => $_POST['name'],
+                ':phone' => $_POST['phone'],
+                ':address' => $_POST['address'],
+                ':email' => $_POST['email'],
+                ':id' => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
+        }
         header('Location: company');
         exit;
     } elseif ($action === 'delete') {

--- a/customers.php
+++ b/customers.php
@@ -47,21 +47,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE customers SET company_id = :company, first_name = :first, last_name = :last, title = :title, email = :email, phone = :phone, address = :address WHERE id = :id");
-        $stmt->execute([
-            ':company' => $_POST['company_id'],
-            ':first' => $_POST['first_name'],
-            ':last' => $_POST['last_name'],
-            ':title' => $_POST['title'],
-            ':email' => $_POST['email'],
-            ':phone' => $_POST['phone'],
-            ':address' => $_POST['address'],
-            ':id' => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
+        $hasChanges = $oldData['company_id'] != $_POST['company_id'] ||
+                      $oldData['first_name'] !== $_POST['first_name'] ||
+                      $oldData['last_name'] !== $_POST['last_name'] ||
+                      $oldData['title'] !== $_POST['title'] ||
+                      $oldData['email'] !== $_POST['email'] ||
+                      $oldData['phone'] !== $_POST['phone'] ||
+                      $oldData['address'] !== $_POST['address'];
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE customers SET company_id = :company, first_name = :first, last_name = :last, title = :title, email = :email, phone = :phone, address = :address WHERE id = :id");
+            $stmt->execute([
+                ':company' => $_POST['company_id'],
+                ':first' => $_POST['first_name'],
+                ':last' => $_POST['last_name'],
+                ':title' => $_POST['title'],
+                ':email' => $_POST['email'],
+                ':phone' => $_POST['phone'],
+                ':address' => $_POST['address'],
+                ':id' => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
+        }
         header('Location: customers');
         exit;
     } elseif ($action === 'delete') {

--- a/customers.php
+++ b/customers.php
@@ -121,9 +121,9 @@ $customers = $stmt->fetchAll();
     <div class="container py-4">
         <h2 class="mb-4">Müşteriler</h2>
         <?php if (!$canAddCustomer): ?>
-            <div class="alert alert-warning">
-                Müşteri ekleyebilmek için önce <a href="company" class="alert-link">firma</a> eklemelisiniz.
-            </div>
+        <div class="alert alert-warning">
+            Müşteri ekleyebilmek için önce <a href="company" class="alert-link">firma</a> eklemelisiniz.
+        </div>
         <?php endif; ?>
         <div class="row mb-3">
 
@@ -144,11 +144,11 @@ $customers = $stmt->fetchAll();
                     <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
                 </form>
                 <?php if ($canAddCustomer): ?>
-                    <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
-                        data-bs-target="#addModal">Müşteri
-                        Ekle</button>
+                <button type="button" class="btn btn-<?php echo get_color(); ?>" data-bs-toggle="modal"
+                    data-bs-target="#addModal">Müşteri
+                    Ekle</button>
                 <?php else: ?>
-                    <a href="company" class="btn btn-<?php echo get_color(); ?>">Firma Ekle</a>
+                <a href="company" class="btn btn-<?php echo get_color(); ?>">Firma Ekle</a>
                 <?php endif; ?>
                 <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
                     <a href="<?php echo $listUrl; ?>"
@@ -162,221 +162,233 @@ $customers = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped responsive-table">
-                <thead>
-                    <tr>
-                        <th>İsim</th>
-                        <th>Soyisim</th>
-                        <th>Firma</th>
-                        <th>Ünvan</th>
-                        <th>Email</th>
-                        <th>Telefon</th>
-                        <th>Adres</th>
-                        <th class="text-center actions-col">İşlemler</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($customers as $customer): ?>
-                        <tr>
-                            <td><?php echo htmlspecialchars($customer['first_name']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['last_name']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['company_name']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['title']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['email']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['phone']); ?></td>
-                            <td><?php echo htmlspecialchars($customer['address']); ?></td>
-                            <td class="text-center">
-                                <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                <?php if (is_admin($pdo)): ?>
-                                <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                <?php endif; ?>
-                                <form method="post" action="customers" class="d-inline-block"
-                                    onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                    <input type="hidden" name="action" value="delete">
-                                    <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                </form>
-                            </td>
-                        </tr>
-
-                        <!-- Edit Modal -->
-                        <div class="modal fade" id="editModal<?php echo $customer['id']; ?>" tabindex="-1" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Müşteri Düzenle</h5>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                            aria-label="Close"></button>
-                                    </div>
-                                    <form method="post" action="customers">
-                                        <div class="modal-body">
-                                            <input type="hidden" name="action" value="edit">
-                                            <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                            <div class="mb-3">
-                                                <label class="form-label">İsim</label>
-                                                <input type="text" name="first_name"
-                                                    value="<?php echo htmlspecialchars($customer['first_name']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Soyisim</label>
-                                                <input type="text" name="last_name"
-                                                    value="<?php echo htmlspecialchars($customer['last_name']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Firma</label>
-                                                <select name="company_id" class="form-select" required>
-                                                    <?php foreach ($companies as $co): ?>
-                                                        <option value="<?php echo $co['id']; ?>" <?php echo ($customer['company_id'] == $co['id']) ? 'selected' : ''; ?>>
-                                                            <?php echo htmlspecialchars($co['name']); ?>
-                                                        </option>
-                                                    <?php endforeach; ?>
-                                                </select>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Ünvan</label>
-                                                <select name="title" class="form-select">
-                                                    <option value="Hanım" <?php echo $customer['title'] === 'Hanım' ? 'selected' : ''; ?>>Hanım</option>
-                                                    <option value="Bey" <?php echo $customer['title'] === 'Bey' ? 'selected' : ''; ?>>
-                                                        Bey</option>
-                                                </select>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Email</label>
-                                                <input type="email" name="email"
-                                                    value="<?php echo htmlspecialchars($customer['email']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Telefon</label>
-                                                <input type="text" name="phone"
-                                                    value="<?php echo htmlspecialchars($customer['phone']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Adres</label>
-                                                <input type="text" name="address"
-                                                    value="<?php echo htmlspecialchars($customer['address']); ?>"
-                                                    class="form-control">
-                                            </div>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="button" class="btn btn-secondary"
-                                                data-bs-dismiss="modal">Kapat</button>
-                                            <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php else: ?>
-            <div class="row g-3 cards-row">
+        <table class="table table-bordered table-striped responsive-table">
+            <thead>
+                <tr>
+                    <th>İsim</th>
+                    <th>Soyisim</th>
+                    <th>Firma</th>
+                    <th>Ünvan</th>
+                    <th>Email</th>
+                    <th>Telefon</th>
+                    <th>Adres</th>
+                    <th class="text-center actions-col">İşlemler</th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php foreach ($customers as $customer): ?>
-                    <div class="col-12 col-md-4">
-                        <div class="card mb-3">
-                            <div class="card-body">
-                                <h5 class="card-title">
-                                    <?php echo htmlspecialchars($customer['first_name'] . ' ' . $customer['last_name']); ?></h5>
-                                <p class="card-text">
-                                    Firma: <?php echo htmlspecialchars($customer['company_name']); ?><br>
-                                    Ünvan: <?php echo htmlspecialchars($customer['title']); ?><br>
-                                    Email: <?php echo htmlspecialchars($customer['email']); ?><br>
-                                    Telefon: <?php echo htmlspecialchars($customer['phone']); ?><br>
-                                    Adres: <?php echo htmlspecialchars($customer['address']); ?>
-                                </p>
-                                <div class="text-end">
-                                    <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $customer['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                    <?php if (is_admin($pdo)): ?>
-                                    <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                    <?php endif; ?>
-                                    <form method="post" action="customers" class="d-inline-block"
-                                        onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                        <input type="hidden" name="action" value="delete">
-                                        <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <tr>
+                    <td><?php echo htmlspecialchars($customer['first_name']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['last_name']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['company_name']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['title']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['email']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['phone']); ?></td>
+                    <td><?php echo htmlspecialchars($customer['address']); ?></td>
+                    <td class="text-center">
+                        <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                            data-bs-target="#editModal<?php echo $customer['id']; ?>"><i
+                                class="bi bi-pencil"></i></button>
+                        <?php if (is_admin($pdo)): ?>
+                        <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>"
+                            class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                        <?php endif; ?>
+                        <form method="post" action="customers" class="d-inline-block"
+                            onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
+                            <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                        </form>
+                    </td>
+                </tr>
 
-                    <!-- Edit Modal -->
-                    <div class="modal fade" id="editModal<?php echo $customer['id']; ?>" tabindex="-1" aria-hidden="true">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Müşteri Düzenle</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <form method="post" action="customers">
-                                    <div class="modal-body">
-                                        <input type="hidden" name="action" value="edit">
-                                        <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
-                                        <div class="mb-3">
-                                            <label class="form-label">İsim</label>
-                                            <input type="text" name="first_name"
-                                                value="<?php echo htmlspecialchars($customer['first_name']); ?>"
-                                                class="form-control" required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Soyisim</label>
-                                            <input type="text" name="last_name"
-                                                value="<?php echo htmlspecialchars($customer['last_name']); ?>"
-                                                class="form-control" required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Firma</label>
-                                            <select name="company_id" class="form-select" required>
-                                                <?php foreach ($companies as $co): ?>
-                                                    <option value="<?php echo $co['id']; ?>" <?php echo ($customer['company_id'] == $co['id']) ? 'selected' : ''; ?>>
-                                                        <?php echo htmlspecialchars($co['name']); ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Ünvan</label>
-                                            <select name="title" class="form-select">
-                                                <option value="Hanım" <?php echo $customer['title'] === 'Hanım' ? 'selected' : ''; ?>>Hanım</option>
-                                                <option value="Bey" <?php echo $customer['title'] === 'Bey' ? 'selected' : ''; ?>>
-                                                    Bey</option>
-                                            </select>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Email</label>
-                                            <input type="email" name="email"
-                                                value="<?php echo htmlspecialchars($customer['email']); ?>"
-                                                class="form-control">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Telefon</label>
-                                            <input type="text" name="phone"
-                                                value="<?php echo htmlspecialchars($customer['phone']); ?>"
-                                                class="form-control">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Adres</label>
-                                            <input type="text" name="address"
-                                                value="<?php echo htmlspecialchars($customer['address']); ?>"
-                                                class="form-control">
-                                        </div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                        <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                    </div>
-                                </form>
+                <!-- Edit Modal -->
+                <div class="modal fade" id="editModal<?php echo $customer['id']; ?>" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Müşteri Düzenle</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                    aria-label="Close"></button>
                             </div>
+                            <form method="post" action="customers">
+                                <div class="modal-body">
+                                    <input type="hidden" name="action" value="edit">
+                                    <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
+                                    <div class="mb-3">
+                                        <label class="form-label">İsim</label>
+                                        <input type="text" name="first_name"
+                                            value="<?php echo htmlspecialchars($customer['first_name']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Soyisim</label>
+                                        <input type="text" name="last_name"
+                                            value="<?php echo htmlspecialchars($customer['last_name']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Firma</label>
+                                        <select name="company_id" class="form-select" required>
+                                            <?php foreach ($companies as $co): ?>
+                                            <option value="<?php echo $co['id']; ?>"
+                                                <?php echo ($customer['company_id'] == $co['id']) ? 'selected' : ''; ?>>
+                                                <?php echo htmlspecialchars($co['name']); ?>
+                                            </option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Ünvan</label>
+                                        <select name="title" class="form-select">
+                                            <option value="Hanım"
+                                                <?php echo $customer['title'] === 'Hanım' ? 'selected' : ''; ?>>Hanım
+                                            </option>
+                                            <option value="Bey"
+                                                <?php echo $customer['title'] === 'Bey' ? 'selected' : ''; ?>>
+                                                Bey</option>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Email</label>
+                                        <input type="email" name="email"
+                                            value="<?php echo htmlspecialchars($customer['email']); ?>"
+                                            class="form-control">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Telefon</label>
+                                        <input type="text" name="phone"
+                                            value="<?php echo htmlspecialchars($customer['phone']); ?>"
+                                            class="form-control">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Adres</label>
+                                        <input type="text" name="address"
+                                            value="<?php echo htmlspecialchars($customer['address']); ?>"
+                                            class="form-control">
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary"
+                                        data-bs-dismiss="modal">Kapat</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                                </div>
+                            </form>
                         </div>
                     </div>
+                </div>
                 <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php else: ?>
+        <div class="row g-3 cards-row">
+            <?php foreach ($customers as $customer): ?>
+            <div class="col-12 col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            <?php echo htmlspecialchars($customer['first_name'] . ' ' . $customer['last_name']); ?></h5>
+                        <p class="card-text">
+                            Firma: <?php echo htmlspecialchars($customer['company_name']); ?><br>
+                            Ünvan: <?php echo htmlspecialchars($customer['title']); ?><br>
+                            Email: <?php echo htmlspecialchars($customer['email']); ?><br>
+                            Telefon: <?php echo htmlspecialchars($customer['phone']); ?><br>
+                            Adres: <?php echo htmlspecialchars($customer['address']); ?>
+                        </p>
+                        <div class="text-end">
+                            <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                                data-bs-target="#editModal<?php echo $customer['id']; ?>"><i
+                                    class="bi bi-pencil"></i></button>
+                            <?php if (is_admin($pdo)): ?>
+                            <a href="log-list.php?table=customers&id=<?php echo $customer['id']; ?>"
+                                class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                            <?php endif; ?>
+                            <form method="post" action="customers" class="d-inline-block"
+                                onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
+                                <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </div>
+
+            <!-- Edit Modal -->
+            <div class="modal fade" id="editModal<?php echo $customer['id']; ?>" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Müşteri Düzenle</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <form method="post" action="customers">
+                            <div class="modal-body">
+                                <input type="hidden" name="action" value="edit">
+                                <input type="hidden" name="id" value="<?php echo $customer['id']; ?>">
+                                <div class="mb-3">
+                                    <label class="form-label">İsim</label>
+                                    <input type="text" name="first_name"
+                                        value="<?php echo htmlspecialchars($customer['first_name']); ?>"
+                                        class="form-control" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Soyisim</label>
+                                    <input type="text" name="last_name"
+                                        value="<?php echo htmlspecialchars($customer['last_name']); ?>"
+                                        class="form-control" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Firma</label>
+                                    <select name="company_id" class="form-select" required>
+                                        <?php foreach ($companies as $co): ?>
+                                        <option value="<?php echo $co['id']; ?>"
+                                            <?php echo ($customer['company_id'] == $co['id']) ? 'selected' : ''; ?>>
+                                            <?php echo htmlspecialchars($co['name']); ?>
+                                        </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Ünvan</label>
+                                    <select name="title" class="form-select">
+                                        <option value="Hanım"
+                                            <?php echo $customer['title'] === 'Hanım' ? 'selected' : ''; ?>>Hanım
+                                        </option>
+                                        <option value="Bey"
+                                            <?php echo $customer['title'] === 'Bey' ? 'selected' : ''; ?>>
+                                            Bey</option>
+                                    </select>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Email</label>
+                                    <input type="email" name="email"
+                                        value="<?php echo htmlspecialchars($customer['email']); ?>"
+                                        class="form-control">
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Telefon</label>
+                                    <input type="text" name="phone"
+                                        value="<?php echo htmlspecialchars($customer['phone']); ?>"
+                                        class="form-control">
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Adres</label>
+                                    <input type="text" name="address"
+                                        value="<?php echo htmlspecialchars($customer['address']); ?>"
+                                        class="form-control">
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
         <?php endif; ?>
     </div>
     <!-- Filter Modal -->
@@ -398,7 +410,8 @@ $customers = $stmt->fetchAll();
                             <label class="form-label">Sıralama</label>
                             <select name="sort" class="form-select">
                                 <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
-                                <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                                <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya
+                                </option>
                             </select>
                         </div>
                     </div>
@@ -433,9 +446,9 @@ $customers = $stmt->fetchAll();
                             <label class="form-label">Firma</label>
                             <select name="company_id" class="form-select" required>
                                 <?php foreach ($companies as $co): ?>
-                                    <option value="<?php echo $co['id']; ?>">
-                                        <?php echo htmlspecialchars($co['name']); ?>
-                                    </option>
+                                <option value="<?php echo $co['id']; ?>">
+                                    <?php echo htmlspecialchars($co['name']); ?>
+                                </option>
                                 <?php endforeach; ?>
                             </select>
                         </div>

--- a/offer.php
+++ b/offer.php
@@ -16,14 +16,16 @@ load_theme_settings($pdo);
 ?>
 <!DOCTYPE html>
 <html lang="tr">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Teklifler</title>
     <link href="<?php echo theme_css(); ?>" rel="stylesheet">
 </head>
+
 <body class="bg-light">
-<?php
+    <?php
 
 // Load companies and customers
 $companyStmt = $pdo->query("SELECT id, name FROM companies ORDER BY name");
@@ -129,56 +131,62 @@ $cardUrl = 'offer?' . http_build_query($p);
 
 include 'includes/header.php';
 ?>
-<div class="container py-4">
-    <h2 class="mb-4">Teklifler</h2>
-    <?php if (!$canAdd): ?>
+    <div class="container py-4">
+        <h2 class="mb-4">Teklifler</h2>
+        <?php if (!$canAdd): ?>
         <div class="alert alert-warning">
-            Teklif ekleyebilmek için önce <a href="company" class="alert-link">firma</a> ve <a href="customers" class="alert-link">müşteri</a> eklemelisiniz.
+            Teklif ekleyebilmek için önce <a href="company" class="alert-link">firma</a> ve <a href="customers"
+                class="alert-link">müşteri</a> eklemelisiniz.
         </div>
-    <?php endif; ?>
-    <div class="row mb-3">
-        <div class="col-12 text-end">
-            <form method="get" class="form-inline-responsive d-inline-block me-2">
-                <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Teklif ara">
-                <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
-                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
-                <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
-            </form>
-            <form method="get" class="form-inline-responsive d-inline-block me-2">
-                <select name="sort" class="form-select" onchange="this.form.submit()">
-                    <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
-                    <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
-                </select>
-                <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
-                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
-            </form>
-            <?php if ($canAdd): ?>
+        <?php endif; ?>
+        <div class="row mb-3">
+            <div class="col-12 text-end">
+                <form method="get" class="form-inline-responsive d-inline-block me-2">
+                    <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>"
+                        class="form-control" placeholder="Teklif ara">
+                    <input type="hidden" name="sort" value="<?php echo strtolower($sort); ?>">
+                    <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?> ms-2">Ara</button>
+                </form>
+                <form method="get" class="form-inline-responsive d-inline-block me-2">
+                    <select name="sort" class="form-select" onchange="this.form.submit()">
+                        <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                        <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                    </select>
+                    <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
+                    <input type="hidden" name="view" value="<?php echo htmlspecialchars($view); ?>">
+                </form>
+                <?php if ($canAdd): ?>
                 <a href="offer_form" class="btn btn-<?php echo get_color(); ?>">Teklif Ekle</a>
-            <?php endif; ?>
-            <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
-                <a href="<?php echo $listUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i class="bi bi-list"></i></a>
-                <a href="<?php echo $cardUrl; ?>" class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i class="bi bi-grid"></i></a>
+                <?php endif; ?>
+                <div class="btn-group ms-2 view-toggle d-none d-md-inline-flex" role="group">
+                    <a href="<?php echo $listUrl; ?>"
+                        class="btn btn-outline-secondary <?php echo $view === 'list' ? 'active' : ''; ?>"><i
+                            class="bi bi-list"></i></a>
+                    <a href="<?php echo $cardUrl; ?>"
+                        class="btn btn-outline-secondary <?php echo $view === 'card' ? 'active' : ''; ?>"><i
+                            class="bi bi-grid"></i></a>
+                </div>
             </div>
         </div>
-    </div>
 
-    <?php if ($view === 'list'): ?>
-    <table class="table table-bordered table-striped responsive-table">
-        <thead>
-            <tr>
-                <th>Firma</th>
-                <th>Müşteri</th>
-                <th>Tarih</th>
-                <th>Teslimat Süresi</th>
-                <th>Ödeme Yöntemi</th>
-                <th>Ödeme Süresi</th>
-                <th>Teklif Süresi</th>
-                <th>Vade</th>
-                <th class="text-center actions-col">İşlemler</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($quotes as $q): ?>
+        <?php if ($view === 'list'): ?>
+        <table class="table table-bordered table-striped responsive-table">
+            <thead>
+                <tr>
+                    <th>Firma</th>
+                    <th>Müşteri</th>
+                    <th>Tarih</th>
+                    <th>Teslimat Süresi</th>
+                    <th>Ödeme Yöntemi</th>
+                    <th>Ödeme Süresi</th>
+                    <th>Teklif Süresi</th>
+                    <th>Vade</th>
+                    <th class="text-center actions-col">İşlemler</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($quotes as $q): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($q['company_name']); ?></td>
                     <td><?php echo htmlspecialchars($q['customer_name']); ?></td>
@@ -189,26 +197,30 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['quote_validity']); ?></td>
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
                     <td class="text-center">
-                        <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i class="bi bi-pencil"></i></a>
+                        <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i
+                                class="bi bi-pencil"></i></a>
                         <?php if (is_admin($pdo)): ?>
-                        <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                        <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>"
+                            class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
                         <?php endif; ?>
-                        <a href="pdf.php?id=<?php echo $q['id']; ?>" target="_blank" class="btn btn-sm bg-light text-dark" title="PDF">
+                        <a href="pdf.php?id=<?php echo $q['id']; ?>" target="_blank"
+                            class="btn btn-sm bg-light text-dark" title="PDF">
                             <i class="bi bi-file-earmark-pdf"></i>
                         </a>
-                        <form method="post" action="offer" class="d-inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                        <form method="post" action="offer" class="d-inline-block"
+                            onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
                             <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
                         </form>
                     </td>
                 </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-    <?php else: ?>
-    <div class="row g-3 cards-row">
-        <?php foreach ($quotes as $q): ?>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php else: ?>
+        <div class="row g-3 cards-row">
+            <?php foreach ($quotes as $q): ?>
             <div class="col-12 col-md-4">
                 <div class="card mb-3">
                     <div class="card-body">
@@ -223,14 +235,18 @@ include 'includes/header.php';
                             Vade: <?php echo htmlspecialchars($q['maturity']); ?>
                         </p>
                         <div class="text-end">
-                            <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i class="bi bi-pencil"></i></a>
+                            <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i
+                                    class="bi bi-pencil"></i></a>
                             <?php if (is_admin($pdo)): ?>
-                            <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                            <a href="log-list.php?table=master_quotes&id=<?php echo $q['id']; ?>"
+                                class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
                             <?php endif; ?>
-                            <a href="pdf.php?id=<?php echo $q['id']; ?>" target="_blank" class="btn btn-sm bg-light text-dark" title="PDF">
+                            <a href="pdf.php?id=<?php echo $q['id']; ?>" target="_blank"
+                                class="btn btn-sm bg-light text-dark" title="PDF">
                                 <i class="bi bi-file-earmark-pdf"></i>
                             </a>
-                            <form method="post" action="offer" class="d-inline-block" onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                            <form method="post" action="offer" class="d-inline-block"
+                                onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?php echo $q['id']; ?>">
                                 <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
@@ -239,38 +255,40 @@ include 'includes/header.php';
                     </div>
                 </div>
             </div>
-        <?php endforeach; ?>
+            <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
     </div>
-    <?php endif; ?>
-</div>
-<!-- Filter Modal -->
-<div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <form class="modal-content" method="get" action="offer">
-            <div class="modal-header">
-                <h5 class="modal-title">Filtrele</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="mb-3">
-                    <label class="form-label">Ara</label>
-                    <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>" class="form-control" placeholder="Teklif ara">
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <form class="modal-content" method="get" action="offer">
+                <div class="modal-header">
+                    <h5 class="modal-title">Filtrele</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="mb-3">
-                    <label class="form-label">Sıralama</label>
-                    <select name="sort" class="form-select">
-                        <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
-                        <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
-                    </select>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Ara</label>
+                        <input type="text" name="search" value="<?php echo htmlspecialchars($search); ?>"
+                            class="form-control" placeholder="Teklif ara">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Sıralama</label>
+                        <select name="sort" class="form-select">
+                            <option value="asc" <?php echo $sort === 'ASC' ? 'selected' : ''; ?>>A'dan Z'ye</option>
+                            <option value="desc" <?php echo $sort === 'DESC' ? 'selected' : ''; ?>>Z'den A'ya</option>
+                        </select>
+                    </div>
                 </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Filtrele</button>
-            </div>
-        </form>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Filtrele</button>
+                </div>
+            </form>
+        </div>
     </div>
-</div>
 
 </body>
+
 </html>

--- a/offer.php
+++ b/offer.php
@@ -61,22 +61,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id");
-        $stmt->execute([
-            ':company'  => $_POST['company_id'],
-            ':contact'  => $_POST['contact_id'],
-            ':date'     => $_POST['quote_date'],
-            ':delivery' => $_POST['delivery_term'],
-            ':method'   => $_POST['payment_method'],
-            ':due'      => $_POST['payment_due'],
-            ':validity' => $_POST['quote_validity'],
-            ':maturity' => $_POST['maturity'],
-            ':id'       => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        $hasChanges = $oldData['company_id'] != $_POST['company_id'] ||
+                      $oldData['contact_id'] != $_POST['contact_id'] ||
+                      $oldData['quote_date'] !== $_POST['quote_date'] ||
+                      $oldData['delivery_term'] !== $_POST['delivery_term'] ||
+                      $oldData['payment_method'] !== $_POST['payment_method'] ||
+                      $oldData['payment_due'] !== $_POST['payment_due'] ||
+                      $oldData['quote_validity'] !== $_POST['quote_validity'] ||
+                      $oldData['maturity'] !== $_POST['maturity'];
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id");
+            $stmt->execute([
+                ':company'  => $_POST['company_id'],
+                ':contact'  => $_POST['contact_id'],
+                ':date'     => $_POST['quote_date'],
+                ':delivery' => $_POST['delivery_term'],
+                ':method'   => $_POST['payment_method'],
+                ':due'      => $_POST['payment_due'],
+                ':validity' => $_POST['quote_validity'],
+                ':maturity' => $_POST['maturity'],
+                ':id'       => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        }
         header('Location: offer');
         exit;
     } elseif ($action === 'delete') {

--- a/product.php
+++ b/product.php
@@ -74,21 +74,33 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $imageData = $oldData['image_data'];
             $imageType = $oldData['image_type'];
         }
-        $stmt = $pdo->prepare("UPDATE products SET name = :name, code = :code, unit = :unit, measure_value = :measure_value, unit_price = :unit_price, category = :category, image_data = :image_data, image_type = :image_type WHERE id = :id");
-        $stmt->bindParam(':name', $_POST['name']);
-        $stmt->bindParam(':code', $_POST['code']);
-        $stmt->bindParam(':unit', $unit);
-        $stmt->bindParam(':measure_value', $measureValue);
-        $stmt->bindParam(':unit_price', $_POST['unit_price']);
-        $stmt->bindParam(':category', $category);
-        $stmt->bindParam(':image_data', $imageData, PDO::PARAM_LOB);
-        $stmt->bindParam(':image_type', $imageType);
-        $stmt->bindParam(':id', $id);
-        $stmt->execute();
-        $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'products', $id, 'update', $oldData, $newData);
+
+        $hasChanges = $oldData['name'] !== $_POST['name'] ||
+                      $oldData['code'] !== $_POST['code'] ||
+                      $oldData['unit'] !== $unit ||
+                      (float)$oldData['measure_value'] != (float)$measureValue ||
+                      (float)$oldData['unit_price'] != (float)$_POST['unit_price'] ||
+                      $oldData['category'] !== $category ||
+                      $oldData['image_data'] !== $imageData ||
+                      $oldData['image_type'] !== $imageType;
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE products SET name = :name, code = :code, unit = :unit, measure_value = :measure_value, unit_price = :unit_price, category = :category, image_data = :image_data, image_type = :image_type WHERE id = :id");
+            $stmt->bindParam(':name', $_POST['name']);
+            $stmt->bindParam(':code', $_POST['code']);
+            $stmt->bindParam(':unit', $unit);
+            $stmt->bindParam(':measure_value', $measureValue);
+            $stmt->bindParam(':unit_price', $_POST['unit_price']);
+            $stmt->bindParam(':category', $category);
+            $stmt->bindParam(':image_data', $imageData, PDO::PARAM_LOB);
+            $stmt->bindParam(':image_type', $imageType);
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'products', $id, 'update', $oldData, $newData);
+        }
         header('Location: product');
         exit;
     } elseif ($action === 'delete') {

--- a/product.php
+++ b/product.php
@@ -176,9 +176,9 @@ $products = $stmt->fetchAll();
                     <select name="category" class="form-select" onchange="this.form.submit()">
                         <option value="">Tüm Kategoriler</option>
                         <?php foreach ($categories as $cat): ?>
-                            <option value="<?php echo $cat; ?>" <?php echo ($categoryFilter === $cat) ? 'selected' : ''; ?>>
-                                <?php echo htmlspecialchars($cat); ?>
-                            </option>
+                        <option value="<?php echo $cat; ?>" <?php echo ($categoryFilter === $cat) ? 'selected' : ''; ?>>
+                            <?php echo htmlspecialchars($cat); ?>
+                        </option>
                         <?php endforeach; ?>
                     </select>
                     <input type="hidden" name="search" value="<?php echo htmlspecialchars($search); ?>">
@@ -201,230 +201,239 @@ $products = $stmt->fetchAll();
         </div>
 
         <?php if ($view === 'list'): ?>
-            <table class="table table-bordered table-striped responsive-table">
-                <thead>
-                    <tr>
-                        <th>Ad</th>
-                        <th>Kod</th>
-                        <th>Ölçü Birimi</th>
-                        <th>Ölçü Değeri</th>
-                        <th>Birim Fiyat</th>
-                        <th>Kategori</th>
-                        <th class="text-center actions-col">İşlemler</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($products as $product): ?>
-                        <tr>
-                            <td><?php echo htmlspecialchars($product['name']); ?></td>
-                            <td><?php echo htmlspecialchars($product['code']); ?></td>
-                            <td><?php echo htmlspecialchars($product['unit']); ?></td>
-                            <td><?php echo htmlspecialchars($product['measure_value']); ?></td>
-                            <td><?php echo htmlspecialchars($product['unit_price']); ?></td>
-                            <td><?php echo htmlspecialchars($product['category']); ?></td>
-                            <td class="text-center">
-                                <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                    data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                <?php if (is_admin($pdo)): ?>
-                                <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                <?php endif; ?>
-                                <form method="post" action="product" class="d-inline-block"
-                                    onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                    <input type="hidden" name="action" value="delete">
-                                    <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                    <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                </form>
-                            </td>
-                        </tr>
-
-                        <!-- Edit Modal -->
-                        <div class="modal fade" id="editModal<?php echo $product['id']; ?>" tabindex="-1" aria-hidden="true">
-                            <div class="modal-dialog">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Ürün Düzenle</h5>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                            aria-label="Close"></button>
-                                    </div>
-                                    <form method="post" action="product" enctype="multipart/form-data">
-                                        <div class="modal-body">
-                                            <input type="hidden" name="action" value="edit">
-                                            <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                            <div class="mb-3">
-                                                <label class="form-label">Ad</label>
-                                                <input type="text" name="name"
-                                                    value="<?php echo htmlspecialchars($product['name']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Kod</label>
-                                                <input type="text" name="code"
-                                                    value="<?php echo htmlspecialchars($product['code']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Kategori</label>
-                                                <select name="category" class="form-select category-select"
-                                                    data-unit="unit<?php echo $product['id']; ?>">
-                                                    <?php foreach ($categories as $cat): ?>
-                                                        <option value="<?php echo $cat; ?>" <?php echo ($product['category'] === $cat) ? 'selected' : ''; ?>>
-                                                            <?php echo htmlspecialchars($cat); ?>
-                                                        </option>
-                                                    <?php endforeach; ?>
-                                                </select>
-                                            </div>
-                                            <div class="mb-3" id="unitWrapper<?php echo $product['id']; ?>">
-                                                <label class="form-label">Ölçü Birimi</label>
-                                                <select name="unit" id="unit<?php echo $product['id']; ?>"
-                                                    class="form-select unit-select"
-                                                    data-target="measure<?php echo $product['id']; ?>"
-                                                    data-wrapper="unitWrapper<?php echo $product['id']; ?>" required>
-                                                    <?php foreach ($units as $unitOption): ?>
-                                                        <option value="<?php echo $unitOption; ?>" <?php echo ($product['unit'] === $unitOption) ? 'selected' : ''; ?>>
-                                                            <?php echo htmlspecialchars($unitOption); ?>
-                                                        </option>
-                                                    <?php endforeach; ?>
-                                                </select>
-                                            </div>
-                                            <div class="mb-3" id="measureWrapper<?php echo $product['id']; ?>">
-                                                <label class="form-label" id="measure<?php echo $product['id']; ?>Label">Ölçü
-                                                    Değeri</label>
-                                                <input type="number" step="0.001" name="measure_value"
-                                                    id="measure<?php echo $product['id']; ?>"
-                                                    value="<?php echo htmlspecialchars($product['measure_value']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                            <label class="form-label">Birim Fiyat</label>
-                                            <input type="number" step="0.01" name="unit_price"
-                                                    value="<?php echo htmlspecialchars($product['unit_price']); ?>"
-                                                    class="form-control" required>
-                                            </div>
-                                            <div class="mb-3">
-                                                <label class="form-label">Görsel</label>
-                                                <input type="file" name="image" accept=".jpg,.jpeg,.png,.webp" class="form-control">
-                                            </div>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="button" class="btn btn-secondary"
-                                                data-bs-dismiss="modal">Kapat</button>
-                                            <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php else: ?>
-            <div class="row g-3 cards-row">
+        <table class="table table-bordered table-striped responsive-table">
+            <thead>
+                <tr>
+                    <th>Ad</th>
+                    <th>Kod</th>
+                    <th>Ölçü Birimi</th>
+                    <th>Ölçü Değeri</th>
+                    <th>Birim Fiyat</th>
+                    <th>Kategori</th>
+                    <th class="text-center actions-col">İşlemler</th>
+                </tr>
+            </thead>
+            <tbody>
                 <?php foreach ($products as $product): ?>
-                    <div class="col-12 col-md-4">
-                        <div class="card mb-3">
-                            <div class="card-body">
-                                <h5 class="card-title"><?php echo htmlspecialchars($product['name']); ?>
-                                    (<?php echo htmlspecialchars($product['code']); ?>)</h5>
-                                <p class="card-text">
-                                    Ölçü Birimi: <?php echo htmlspecialchars($product['unit']); ?><br>
-                                    Ölçü Değeri: <?php echo htmlspecialchars($product['measure_value']); ?><br>
-                                    Birim Fiyat: <?php echo htmlspecialchars($product['unit_price']); ?><br>
-                                    Kategori: <?php echo htmlspecialchars($product['category']); ?>
-                                </p>
-                                <div class="text-end">
-                                    <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
-                                        data-bs-target="#editModal<?php echo $product['id']; ?>"><i class="bi bi-pencil"></i></button>
-                                    <?php if (is_admin($pdo)): ?>
-                                    <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>" class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
-                                    <?php endif; ?>
-                                    <form method="post" action="product" class="d-inline-block"
-                                        onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
-                                        <input type="hidden" name="action" value="delete">
-                                        <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                        <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
-                                    </form>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <tr>
+                    <td><?php echo htmlspecialchars($product['name']); ?></td>
+                    <td><?php echo htmlspecialchars($product['code']); ?></td>
+                    <td><?php echo htmlspecialchars($product['unit']); ?></td>
+                    <td><?php echo htmlspecialchars($product['measure_value']); ?></td>
+                    <td><?php echo htmlspecialchars($product['unit_price']); ?></td>
+                    <td><?php echo htmlspecialchars($product['category']); ?></td>
+                    <td class="text-center">
+                        <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                            data-bs-target="#editModal<?php echo $product['id']; ?>"><i
+                                class="bi bi-pencil"></i></button>
+                        <?php if (is_admin($pdo)): ?>
+                        <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>"
+                            class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                        <?php endif; ?>
+                        <form method="post" action="product" class="d-inline-block"
+                            onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
+                            <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                        </form>
+                    </td>
+                </tr>
 
-                    <!-- Edit Modal -->
-                    <div class="modal fade" id="editModal<?php echo $product['id']; ?>" tabindex="-1" aria-hidden="true">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h5 class="modal-title">Ürün Düzenle</h5>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                </div>
-                                <form method="post" action="product" enctype="multipart/form-data">
-                                    <div class="modal-body">
-                                        <input type="hidden" name="action" value="edit">
-                                        <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
-                                        <div class="mb-3">
-                                            <label class="form-label">Ad</label>
-                                            <input type="text" name="name"
-                                                value="<?php echo htmlspecialchars($product['name']); ?>" class="form-control"
-                                                required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Kod</label>
-                                            <input type="text" name="code"
-                                                value="<?php echo htmlspecialchars($product['code']); ?>" class="form-control"
-                                                required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Kategori</label>
-                                            <select name="category" class="form-select category-select"
-                                                data-unit="unit<?php echo $product['id']; ?>">
-                                                <?php foreach ($categories as $cat): ?>
-                                                    <option value="<?php echo $cat; ?>" <?php echo ($product['category'] === $cat) ? 'selected' : ''; ?>>
-                                                        <?php echo htmlspecialchars($cat); ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        </div>
-                                        <div class="mb-3" id="unitWrapper<?php echo $product['id']; ?>">
-                                            <label class="form-label">Ölçü Birimi</label>
-                                            <select name="unit" id="unit<?php echo $product['id']; ?>"
-                                                class="form-select unit-select"
-                                                data-target="measure<?php echo $product['id']; ?>"
-                                                data-wrapper="unitWrapper<?php echo $product['id']; ?>" required>
-                                                <?php foreach ($units as $unitOption): ?>
-                                                    <option value="<?php echo $unitOption; ?>" <?php echo ($product['unit'] === $unitOption) ? 'selected' : ''; ?>>
-                                                        <?php echo htmlspecialchars($unitOption); ?>
-                                                    </option>
-                                                <?php endforeach; ?>
-                                            </select>
-                                        </div>
-                                        <div class="mb-3" id="measureWrapper<?php echo $product['id']; ?>">
-                                            <label class="form-label" id="measure<?php echo $product['id']; ?>Label">Ölçü
-                                                Değeri</label>
-                                            <input type="number" step="0.001" name="measure_value"
-                                                id="measure<?php echo $product['id']; ?>"
-                                                value="<?php echo htmlspecialchars($product['measure_value']); ?>"
-                                                class="form-control" required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Birim Fiyat</label>
-                                            <input type="number" step="0.01" name="unit_price"
-                                                value="<?php echo htmlspecialchars($product['unit_price']); ?>"
-                                                class="form-control" required>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Görsel</label>
-                                            <input type="file" name="image" accept=".jpg,.jpeg,.png,.webp" class="form-control">
-                                        </div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
-                                        <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
-                                    </div>
-                                </form>
+                <!-- Edit Modal -->
+                <div class="modal fade" id="editModal<?php echo $product['id']; ?>" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Ürün Düzenle</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                    aria-label="Close"></button>
                             </div>
+                            <form method="post" action="product" enctype="multipart/form-data">
+                                <div class="modal-body">
+                                    <input type="hidden" name="action" value="edit">
+                                    <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
+                                    <div class="mb-3">
+                                        <label class="form-label">Ad</label>
+                                        <input type="text" name="name"
+                                            value="<?php echo htmlspecialchars($product['name']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Kod</label>
+                                        <input type="text" name="code"
+                                            value="<?php echo htmlspecialchars($product['code']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Kategori</label>
+                                        <select name="category" class="form-select category-select"
+                                            data-unit="unit<?php echo $product['id']; ?>">
+                                            <?php foreach ($categories as $cat): ?>
+                                            <option value="<?php echo $cat; ?>"
+                                                <?php echo ($product['category'] === $cat) ? 'selected' : ''; ?>>
+                                                <?php echo htmlspecialchars($cat); ?>
+                                            </option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3" id="unitWrapper<?php echo $product['id']; ?>">
+                                        <label class="form-label">Ölçü Birimi</label>
+                                        <select name="unit" id="unit<?php echo $product['id']; ?>"
+                                            class="form-select unit-select"
+                                            data-target="measure<?php echo $product['id']; ?>"
+                                            data-wrapper="unitWrapper<?php echo $product['id']; ?>" required>
+                                            <?php foreach ($units as $unitOption): ?>
+                                            <option value="<?php echo $unitOption; ?>"
+                                                <?php echo ($product['unit'] === $unitOption) ? 'selected' : ''; ?>>
+                                                <?php echo htmlspecialchars($unitOption); ?>
+                                            </option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div class="mb-3" id="measureWrapper<?php echo $product['id']; ?>">
+                                        <label class="form-label" id="measure<?php echo $product['id']; ?>Label">Ölçü
+                                            Değeri</label>
+                                        <input type="number" step="0.001" name="measure_value"
+                                            id="measure<?php echo $product['id']; ?>"
+                                            value="<?php echo htmlspecialchars($product['measure_value']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Birim Fiyat</label>
+                                        <input type="number" step="0.01" name="unit_price"
+                                            value="<?php echo htmlspecialchars($product['unit_price']); ?>"
+                                            class="form-control" required>
+                                    </div>
+                                    <div class="mb-3">
+                                        <label class="form-label">Görsel</label>
+                                        <input type="file" name="image" accept=".jpg,.jpeg,.png,.webp"
+                                            class="form-control">
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary"
+                                        data-bs-dismiss="modal">Kapat</button>
+                                    <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                                </div>
+                            </form>
                         </div>
                     </div>
+                </div>
                 <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php else: ?>
+        <div class="row g-3 cards-row">
+            <?php foreach ($products as $product): ?>
+            <div class="col-12 col-md-4">
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title"><?php echo htmlspecialchars($product['name']); ?>
+                            (<?php echo htmlspecialchars($product['code']); ?>)</h5>
+                        <p class="card-text">
+                            Ölçü Birimi: <?php echo htmlspecialchars($product['unit']); ?><br>
+                            Ölçü Değeri: <?php echo htmlspecialchars($product['measure_value']); ?><br>
+                            Birim Fiyat: <?php echo htmlspecialchars($product['unit_price']); ?><br>
+                            Kategori: <?php echo htmlspecialchars($product['category']); ?>
+                        </p>
+                        <div class="text-end">
+                            <button class="btn btn-sm bg-light text-dark" data-bs-toggle="modal"
+                                data-bs-target="#editModal<?php echo $product['id']; ?>"><i
+                                    class="bi bi-pencil"></i></button>
+                            <?php if (is_admin($pdo)): ?>
+                            <a href="log-list.php?table=products&id=<?php echo $product['id']; ?>"
+                                class="btn btn-sm bg-light text-dark" title="Logları Gör"><i class="bi bi-eye"></i></a>
+                            <?php endif; ?>
+                            <form method="post" action="product" class="d-inline-block"
+                                onsubmit="return confirm('Silmek istediğinize emin misiniz?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
+                                <button type="submit" class="btn btn-sm btn-danger"><i class="bi bi-trash"></i></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
             </div>
+
+            <!-- Edit Modal -->
+            <div class="modal fade" id="editModal<?php echo $product['id']; ?>" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Ürün Düzenle</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <form method="post" action="product" enctype="multipart/form-data">
+                            <div class="modal-body">
+                                <input type="hidden" name="action" value="edit">
+                                <input type="hidden" name="id" value="<?php echo $product['id']; ?>">
+                                <div class="mb-3">
+                                    <label class="form-label">Ad</label>
+                                    <input type="text" name="name"
+                                        value="<?php echo htmlspecialchars($product['name']); ?>" class="form-control"
+                                        required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Kod</label>
+                                    <input type="text" name="code"
+                                        value="<?php echo htmlspecialchars($product['code']); ?>" class="form-control"
+                                        required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Kategori</label>
+                                    <select name="category" class="form-select category-select"
+                                        data-unit="unit<?php echo $product['id']; ?>">
+                                        <?php foreach ($categories as $cat): ?>
+                                        <option value="<?php echo $cat; ?>"
+                                            <?php echo ($product['category'] === $cat) ? 'selected' : ''; ?>>
+                                            <?php echo htmlspecialchars($cat); ?>
+                                        </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="mb-3" id="unitWrapper<?php echo $product['id']; ?>">
+                                    <label class="form-label">Ölçü Birimi</label>
+                                    <select name="unit" id="unit<?php echo $product['id']; ?>"
+                                        class="form-select unit-select"
+                                        data-target="measure<?php echo $product['id']; ?>"
+                                        data-wrapper="unitWrapper<?php echo $product['id']; ?>" required>
+                                        <?php foreach ($units as $unitOption): ?>
+                                        <option value="<?php echo $unitOption; ?>"
+                                            <?php echo ($product['unit'] === $unitOption) ? 'selected' : ''; ?>>
+                                            <?php echo htmlspecialchars($unitOption); ?>
+                                        </option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </div>
+                                <div class="mb-3" id="measureWrapper<?php echo $product['id']; ?>">
+                                    <label class="form-label" id="measure<?php echo $product['id']; ?>Label">Ölçü
+                                        Değeri</label>
+                                    <input type="number" step="0.001" name="measure_value"
+                                        id="measure<?php echo $product['id']; ?>"
+                                        value="<?php echo htmlspecialchars($product['measure_value']); ?>"
+                                        class="form-control" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Birim Fiyat</label>
+                                    <input type="number" step="0.01" name="unit_price"
+                                        value="<?php echo htmlspecialchars($product['unit_price']); ?>"
+                                        class="form-control" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Görsel</label>
+                                    <input type="file" name="image" accept=".jpg,.jpeg,.png,.webp" class="form-control">
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Kapat</button>
+                                <button type="submit" class="btn btn-<?php echo get_color(); ?>">Kaydet</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
         <?php endif; ?>
     </div>
     <!-- Filter Modal -->
@@ -453,9 +462,10 @@ $products = $stmt->fetchAll();
                         <select name="category" class="form-select">
                             <option value="">Hepsi</option>
                             <?php foreach ($categories as $cat): ?>
-                                <option value="<?php echo $cat; ?>" <?php echo ($categoryFilter === $cat) ? 'selected' : ''; ?>>
-                                    <?php echo htmlspecialchars($cat); ?>
-                                </option>
+                            <option value="<?php echo $cat; ?>"
+                                <?php echo ($categoryFilter === $cat) ? 'selected' : ''; ?>>
+                                <?php echo htmlspecialchars($cat); ?>
+                            </option>
                             <?php endforeach; ?>
                         </select>
                     </div>
@@ -491,9 +501,9 @@ $products = $stmt->fetchAll();
                             <label class="form-label">Kategori</label>
                             <select name="category" class="form-select category-select" data-unit="addUnit">
                                 <?php foreach ($categories as $cat): ?>
-                                    <option value="<?php echo $cat; ?>">
-                                        <?php echo htmlspecialchars($cat); ?>
-                                    </option>
+                                <option value="<?php echo $cat; ?>">
+                                    <?php echo htmlspecialchars($cat); ?>
+                                </option>
                                 <?php endforeach; ?>
                             </select>
                         </div>
@@ -502,9 +512,9 @@ $products = $stmt->fetchAll();
                             <select name="unit" id="addUnit" class="form-select unit-select" data-target="addMeasure"
                                 data-wrapper="addUnitWrapper" required>
                                 <?php foreach ($units as $unit): ?>
-                                    <option value="<?php echo $unit; ?>">
-                                        <?php echo htmlspecialchars($unit); ?>
-                                    </option>
+                                <option value="<?php echo $unit; ?>">
+                                    <?php echo htmlspecialchars($unit); ?>
+                                </option>
                                 <?php endforeach; ?>
                             </select>
                         </div>
@@ -531,58 +541,63 @@ $products = $stmt->fetchAll();
         </div>
     </div>
     <script>
-        function updateMeasure(selectEl, measureInput, wrapper) {
-            if (selectEl.value === 'adet' || selectEl.value === 'metre') {
-                measureInput.value = 1;
-                if (wrapper) wrapper.style.display = 'none';
-                measureInput.removeAttribute('required');
-            } else {
-                if (wrapper) wrapper.style.display = '';
-                measureInput.setAttribute('required', 'required');
-            }
+    function updateMeasure(selectEl, measureInput, wrapper) {
+        if (selectEl.value === 'adet' || selectEl.value === 'metre') {
+            measureInput.value = 1;
+            if (wrapper) wrapper.style.display = 'none';
+            measureInput.removeAttribute('required');
+        } else {
+            if (wrapper) wrapper.style.display = '';
+            measureInput.setAttribute('required', 'required');
         }
-        var categoryUnits = { 'Aksesuar': 'adet', 'Fitil': 'metre', 'Alüminyum': 'kg' };
-        function updateUnitFromCategory(catSel) {
-            var unitSelect = document.getElementById(catSel.getAttribute('data-unit'));
-            if (!unitSelect) return;
-            var targetUnit = categoryUnits[catSel.value];
-            var unitWrapper = document.getElementById(unitSelect.getAttribute('data-wrapper'));
-            if (targetUnit) {
-                unitSelect.value = targetUnit;
-            }
-            var hideUnit = (catSel.value === 'Aksesuar' || catSel.value === 'Fitil' || catSel.value === 'Alüminyum');
-            if (hideUnit) {
-                if (unitWrapper) unitWrapper.style.display = 'none';
-                unitSelect.removeAttribute('required');
-            } else {
-                if (unitWrapper) unitWrapper.style.display = '';
-                unitSelect.setAttribute('required', 'required');
-            }
-            var measure = document.getElementById(unitSelect.getAttribute('data-target'));
-            var wrapper = document.getElementById(unitSelect.getAttribute('data-target') + 'Wrapper');
-            var label = document.getElementById(unitSelect.getAttribute('data-target') + 'Label');
-            if (label) {
-                label.textContent = (catSel.value === 'Alüminyum') ? 'Gramaj' : 'Ölçü Değeri';
-            }
-            updateMeasure(unitSelect, measure, wrapper);
+    }
+    var categoryUnits = {
+        'Aksesuar': 'adet',
+        'Fitil': 'metre',
+        'Alüminyum': 'kg'
+    };
+
+    function updateUnitFromCategory(catSel) {
+        var unitSelect = document.getElementById(catSel.getAttribute('data-unit'));
+        if (!unitSelect) return;
+        var targetUnit = categoryUnits[catSel.value];
+        var unitWrapper = document.getElementById(unitSelect.getAttribute('data-wrapper'));
+        if (targetUnit) {
+            unitSelect.value = targetUnit;
         }
-        document.addEventListener('DOMContentLoaded', function () {
-            document.querySelectorAll('.unit-select').forEach(function (sel) {
-                var targetId = sel.getAttribute('data-target');
-                var measure = document.getElementById(targetId);
-                var wrapper = document.getElementById(targetId + 'Wrapper');
+        var hideUnit = (catSel.value === 'Aksesuar' || catSel.value === 'Fitil' || catSel.value === 'Alüminyum');
+        if (hideUnit) {
+            if (unitWrapper) unitWrapper.style.display = 'none';
+            unitSelect.removeAttribute('required');
+        } else {
+            if (unitWrapper) unitWrapper.style.display = '';
+            unitSelect.setAttribute('required', 'required');
+        }
+        var measure = document.getElementById(unitSelect.getAttribute('data-target'));
+        var wrapper = document.getElementById(unitSelect.getAttribute('data-target') + 'Wrapper');
+        var label = document.getElementById(unitSelect.getAttribute('data-target') + 'Label');
+        if (label) {
+            label.textContent = (catSel.value === 'Alüminyum') ? 'Gramaj' : 'Ölçü Değeri';
+        }
+        updateMeasure(unitSelect, measure, wrapper);
+    }
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.unit-select').forEach(function(sel) {
+            var targetId = sel.getAttribute('data-target');
+            var measure = document.getElementById(targetId);
+            var wrapper = document.getElementById(targetId + 'Wrapper');
+            updateMeasure(sel, measure, wrapper);
+            sel.addEventListener('change', function() {
                 updateMeasure(sel, measure, wrapper);
-                sel.addEventListener('change', function () {
-                    updateMeasure(sel, measure, wrapper);
-                });
-            });
-            document.querySelectorAll('.category-select').forEach(function (cat) {
-                updateUnitFromCategory(cat);
-                cat.addEventListener('change', function () {
-                    updateUnitFromCategory(cat);
-                });
             });
         });
+        document.querySelectorAll('.category-select').forEach(function(cat) {
+            updateUnitFromCategory(cat);
+            cat.addEventListener('change', function() {
+                updateUnitFromCategory(cat);
+            });
+        });
+    });
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- detect field changes before updating a record in company, customer, product and offer pages
- avoid unnecessary update queries and logs

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_687dfaba1fe08328a2a136814298f12d