### PR TITLE
Add change detection before updates

### DIFF
--- a/company.php
+++ b/company.php
@@ -39,18 +39,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE companies SET name = :name, phone = :phone, address = :address, email = :email WHERE id = :id");
-        $stmt->execute([
-            ':name' => $_POST['name'],
-            ':phone' => $_POST['phone'],
-            ':address' => $_POST['address'],
-            ':email' => $_POST['email'],
-            ':id' => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
+        $newData = [
+            'name' => $_POST['name'],
+            'phone' => $_POST['phone'],
+            'address' => $_POST['address'],
+            'email' => $_POST['email']
+        ];
+
+        $hasChanges = false;
+        foreach ($newData as $field => $value) {
+            if ($oldData[$field] != $value) {
+                $hasChanges = true;
+                break;
+            }
+        }
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE companies SET name = :name, phone = :phone, address = :address, email = :email WHERE id = :id");
+            $stmt->execute([
+                ':name' => $newData['name'],
+                ':phone' => $newData['phone'],
+                ':address' => $newData['address'],
+                ':email' => $newData['email'],
+                ':id' => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM companies WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'companies', $id, 'update', $oldData, $newData);
+        }
         header('Location: company');
         exit;
     } elseif ($action === 'delete') {

--- a/company.php
+++ b/company.php
@@ -48,7 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $hasChanges = false;
         foreach ($newData as $field => $value) {
-            if ($oldData[$field] != $value) {
+            if (!array_key_exists($field, $oldData) || (string)$oldData[$field] !== (string)$value) {
                 $hasChanges = true;
                 break;
             }

--- a/customers.php
+++ b/customers.php
@@ -47,21 +47,41 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE customers SET company_id = :company, first_name = :first, last_name = :last, title = :title, email = :email, phone = :phone, address = :address WHERE id = :id");
-        $stmt->execute([
-            ':company' => $_POST['company_id'],
-            ':first' => $_POST['first_name'],
-            ':last' => $_POST['last_name'],
-            ':title' => $_POST['title'],
-            ':email' => $_POST['email'],
-            ':phone' => $_POST['phone'],
-            ':address' => $_POST['address'],
-            ':id' => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
+        $newData = [
+            'company_id' => $_POST['company_id'],
+            'first_name' => $_POST['first_name'],
+            'last_name'  => $_POST['last_name'],
+            'title'      => $_POST['title'],
+            'email'      => $_POST['email'],
+            'phone'      => $_POST['phone'],
+            'address'    => $_POST['address']
+        ];
+
+        $hasChanges = false;
+        foreach ($newData as $field => $value) {
+            if ($oldData[$field] != $value) {
+                $hasChanges = true;
+                break;
+            }
+        }
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE customers SET company_id = :company, first_name = :first, last_name = :last, title = :title, email = :email, phone = :phone, address = :address WHERE id = :id");
+            $stmt->execute([
+                ':company' => $newData['company_id'],
+                ':first' => $newData['first_name'],
+                ':last' => $newData['last_name'],
+                ':title' => $newData['title'],
+                ':email' => $newData['email'],
+                ':phone' => $newData['phone'],
+                ':address' => $newData['address'],
+                ':id' => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM customers WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'customers', $id, 'update', $oldData, $newData);
+        }
         header('Location: customers');
         exit;
     } elseif ($action === 'delete') {

--- a/customers.php
+++ b/customers.php
@@ -59,7 +59,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $hasChanges = false;
         foreach ($newData as $field => $value) {
-            if ($oldData[$field] != $value) {
+            if (!array_key_exists($field, $oldData) || (string)$oldData[$field] !== (string)$value) {
                 $hasChanges = true;
                 break;
             }

--- a/offer.php
+++ b/offer.php
@@ -61,22 +61,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id");
-        $stmt->execute([
-            ':company'  => $_POST['company_id'],
-            ':contact'  => $_POST['contact_id'],
-            ':date'     => $_POST['quote_date'],
-            ':delivery' => $_POST['delivery_term'],
-            ':method'   => $_POST['payment_method'],
-            ':due'      => $_POST['payment_due'],
-            ':validity' => $_POST['quote_validity'],
-            ':maturity' => $_POST['maturity'],
-            ':id'       => $id
-        ]);
-        $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        $newData = [
+            'company_id'    => $_POST['company_id'],
+            'contact_id'    => $_POST['contact_id'],
+            'quote_date'    => $_POST['quote_date'],
+            'delivery_term' => $_POST['delivery_term'],
+            'payment_method'=> $_POST['payment_method'],
+            'payment_due'   => $_POST['payment_due'],
+            'quote_validity'=> $_POST['quote_validity'],
+            'maturity'      => $_POST['maturity']
+        ];
+
+        $hasChanges = false;
+        foreach ($newData as $field => $value) {
+            if ($oldData[$field] != $value) {
+                $hasChanges = true;
+                break;
+            }
+        }
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id");
+            $stmt->execute([
+                ':company'  => $newData['company_id'],
+                ':contact'  => $newData['contact_id'],
+                ':date'     => $newData['quote_date'],
+                ':delivery' => $newData['delivery_term'],
+                ':method'   => $newData['payment_method'],
+                ':due'      => $newData['payment_due'],
+                ':validity' => $newData['quote_validity'],
+                ':maturity' => $newData['maturity'],
+                ':id'       => $id
+            ]);
+            $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'master_quotes', $id, 'update', $oldData, $newData);
+        }
         header('Location: offer');
         exit;
     } elseif ($action === 'delete') {

--- a/offer.php
+++ b/offer.php
@@ -74,7 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $hasChanges = false;
         foreach ($newData as $field => $value) {
-            if ($oldData[$field] != $value) {
+            if (!array_key_exists($field, $oldData) || (string)$oldData[$field] !== (string)$value) {
                 $hasChanges = true;
                 break;
             }

--- a/product.php
+++ b/product.php
@@ -74,21 +74,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $imageData = $oldData['image_data'];
             $imageType = $oldData['image_type'];
         }
-        $stmt = $pdo->prepare("UPDATE products SET name = :name, code = :code, unit = :unit, measure_value = :measure_value, unit_price = :unit_price, category = :category, image_data = :image_data, image_type = :image_type WHERE id = :id");
-        $stmt->bindParam(':name', $_POST['name']);
-        $stmt->bindParam(':code', $_POST['code']);
-        $stmt->bindParam(':unit', $unit);
-        $stmt->bindParam(':measure_value', $measureValue);
-        $stmt->bindParam(':unit_price', $_POST['unit_price']);
-        $stmt->bindParam(':category', $category);
-        $stmt->bindParam(':image_data', $imageData, PDO::PARAM_LOB);
-        $stmt->bindParam(':image_type', $imageType);
-        $stmt->bindParam(':id', $id);
-        $stmt->execute();
-        $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
-        $stmtNew->execute([':id' => $id]);
-        $newData = $stmtNew->fetch();
-        logAction($pdo, 'products', $id, 'update', $oldData, $newData);
+
+        $newData = [
+            'name'         => $_POST['name'],
+            'code'         => $_POST['code'],
+            'unit'         => $unit,
+            'measure_value'=> $measureValue,
+            'unit_price'   => $_POST['unit_price'],
+            'category'     => $category,
+            'image_data'   => $imageData,
+            'image_type'   => $imageType
+        ];
+
+        $hasChanges = false;
+        foreach ($newData as $field => $value) {
+            if ($oldData[$field] != $value) {
+                $hasChanges = true;
+                break;
+            }
+        }
+
+        if ($hasChanges) {
+            $stmt = $pdo->prepare("UPDATE products SET name = :name, code = :code, unit = :unit, measure_value = :measure_value, unit_price = :unit_price, category = :category, image_data = :image_data, image_type = :image_type WHERE id = :id");
+            $stmt->bindParam(':name', $newData['name']);
+            $stmt->bindParam(':code', $newData['code']);
+            $stmt->bindParam(':unit', $newData['unit']);
+            $stmt->bindParam(':measure_value', $newData['measure_value']);
+            $stmt->bindParam(':unit_price', $newData['unit_price']);
+            $stmt->bindParam(':category', $newData['category']);
+            $stmt->bindParam(':image_data', $newData['image_data'], PDO::PARAM_LOB);
+            $stmt->bindParam(':image_type', $newData['image_type']);
+            $stmt->bindParam(':id', $id);
+            $stmt->execute();
+            $stmtNew = $pdo->prepare('SELECT * FROM products WHERE id = :id');
+            $stmtNew->execute([':id' => $id]);
+            $newData = $stmtNew->fetch();
+            logAction($pdo, 'products', $id, 'update', $oldData, $newData);
+        }
         header('Location: product');
         exit;
     } elseif ($action === 'delete') {

--- a/product.php
+++ b/product.php
@@ -88,7 +88,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $hasChanges = false;
         foreach ($newData as $field => $value) {
-            if ($oldData[$field] != $value) {
+            if (!array_key_exists($field, $oldData) || (string)$oldData[$field] !== (string)$value) {
                 $hasChanges = true;
                 break;
             }


### PR DESCRIPTION
## Summary
- detect field changes before updating a record in company, customer, product and offer pages
- avoid unnecessary update queries and logs

## Testing
- `php -l company.php`
- `php -l customers.php`
- `php -l product.php`
- `php -l offer.php`


------
https://chatgpt.com/codex/tasks/task_e_687dfaba1fe08328a2a136814298f12d