### PR TITLE
Add user-configurable settings helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Ardından tarayıcınızdan `http://localhost:8000` adresini ziyaret edin.
 - Ürün görsellerini veritabanında saklama
 - Teklifleri PDF olarak dışa aktarma
 - Kullanıcı işlemlerini kaydeden denetim (audit) yapısı
+- Uygulama ve kullanıcı bazında ayarlanabilen genel ayar sistemi
 
 ## Örnek
 

--- a/helpers/settings.php
+++ b/helpers/settings.php
@@ -1,0 +1,61 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+const APP_DEFAULT_SETTINGS = [
+    'order_email' => 'orders@example.com',
+    'currency'    => 'USD',
+    'timezone'    => 'UTC',
+    'date_format' => 'Y-m-d H:i',
+];
+
+function get_setting(PDO $pdo, string $key)
+{
+    $userId = $_SESSION['user']['id'] ?? null;
+    static $cache = [];
+    $cacheKey = ($userId ?? 'default') . ':' . $key;
+    if (isset($cache[$cacheKey])) {
+        return $cache[$cacheKey];
+    }
+    if ($userId !== null) {
+        try {
+            $stmt = $pdo->prepare('SELECT value FROM settings WHERE user_id = ? AND `key` = ?');
+            $stmt->execute([$userId, $key]);
+            $val = $stmt->fetchColumn();
+            if ($val !== false) {
+                $val = json_decode($val, true);
+                $cache[$cacheKey] = $val;
+                return $val;
+            }
+        } catch (PDOException $e) {
+            // ignore errors
+        }
+    }
+    $default = APP_DEFAULT_SETTINGS[$key] ?? null;
+    $cache[$cacheKey] = $default;
+    return $default;
+}
+
+function save_user_setting(PDO $pdo, string $key, $value): bool
+{
+    $userId = $_SESSION['user']['id'] ?? null;
+    if ($userId === null) {
+        return false;
+    }
+    try {
+        $stmt = $pdo->prepare(
+            'INSERT INTO settings (user_id, `key`, value) ' .
+            'VALUES (:user, :key, :val) ON DUPLICATE KEY UPDATE value = VALUES(value)'
+        );
+        $stmt->execute([
+            ':user' => $userId,
+            ':key'  => $key,
+            ':val'  => json_encode($value)
+        ]);
+        return true;
+    } catch (PDOException $e) {
+        return false;
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add `helpers/settings.php` for getting and saving settings
- extend **Settings** page to handle order email, currency, timezone and date format
- document new capability in README

## Testing
- `php -l helpers/settings.php`
- `php -l settings.php`

------
https://chatgpt.com/codex/tasks/task_e_687f5d384a8483288f2df074c1249e8a