### PR TITLE
Add cost calculation for guillotine quotes

### DIFF
--- a/offer_form.php
+++ b/offer_form.php
@@ -18,6 +18,104 @@ $customerStmt = $pdo->query("SELECT id, CONCAT(first_name,' ',last_name) AS name
 $customers = $customerStmt->fetchAll();
 $canAdd = count($companies) > 0 && count($customers) > 0;
 
+function calculateGuillotineCost(PDO $pdo, float $width, float $height, int $qty, string $glass): float {
+    $motor_kutusu = $width - 14;
+    $motor_kapak = $motor_kutusu - 1;
+    $alt_kasa = $width;
+    $tutamak = $width - 185;
+    $kenetli_baza = $width - 185;
+    $kupeste_baza = $width - 185;
+    $kupeste = $width - 185;
+    $dikey_baza = ($height - 290) / 3;
+    $kanat = $dikey_baza;
+    $dikme = $height - 166;
+    $orta_dikme = $dikme;
+    $son_kapatma = $height - $kanat - 221;
+    $yatak_citasi = $kenetli_baza - 52;
+    $dikey_citasi = $dikey_baza - 5;
+    $zincir = $son_kapatma + 600;
+    $flatbelt_kayis = $son_kapatma + 600;
+    $motor_borusu = $width - 59;
+    $cam_en = round($width - 219);
+    $cam_boy = round($dikey_baza + 28 - 2);
+    $motor_kutusu_qty = $qty;
+    $motor_kapak_qty = $qty;
+    $alt_kasa_qty = $qty;
+    $kenetli_baza_qty = 2 * $qty;
+    $kupeste_baza_qty = 2 * $qty;
+    $tutamak_qty = 6 * $qty - $kenetli_baza_qty - $kupeste_baza_qty;
+    $kupeste_qty = $qty;
+    if (strtolower($glass) === 'tek cam') {
+        $yatay_citasi_qty = 6 * $qty;
+        $dikey_citasi_qty = 6 * $qty;
+    } else {
+        $yatay_citasi_qty = 0;
+        $dikey_citasi_qty = 0;
+    }
+    $dikme_qty = 2 * $qty;
+    $orta_dikme_qty = 2 * $qty;
+    $son_kapatma_qty = 2 * $qty;
+    $kanat_qty = 2 * $qty;
+    $dikey_baza_qty = 4 * $qty;
+    $zincir_qty = 2 * $qty;
+    $motor_borusu_qty = $qty;
+    $motor_kutu_contasi = (($motor_kutusu * $qty) + ($alt_kasa * $qty)) / 1000;
+    $kanat_contasi = $kanat * $qty * 2 / 1000;
+    $kenet_fitili = (($tutamak * $qty) + ($kenetli_baza * $qty)) / 1000;
+    $kil_fitil = (($dikme * $qty) + ($orta_dikme * $qty * 2) + ($son_kapatma * $qty) + ($kanat * $qty)) / 1000;
+    $cam_adet = ($kanat_qty + $dikey_baza_qty) / 2;
+    $parts = [
+        ['name'=>'Motor Kutusu','length'=>$motor_kutusu,'count'=>$motor_kutusu_qty],
+        ['name'=>'Motor Kapak','length'=>$motor_kapak,'count'=>$motor_kapak_qty],
+        ['name'=>'Alt Kasa','length'=>$alt_kasa,'count'=>$alt_kasa_qty],
+        ['name'=>'Tutamak','length'=>$tutamak,'count'=>$tutamak_qty],
+        ['name'=>'Kenetli Baza','length'=>$kenetli_baza,'count'=>$kenetli_baza_qty],
+        ['name'=>'Küpeşte Baza','length'=>$kupeste_baza,'count'=>$kupeste_baza_qty],
+        ['name'=>'Küpeşte','length'=>$kupeste,'count'=>$kupeste_qty],
+        ['name'=>'Yatay Tek Cam Çıtası','length'=>$yatak_citasi,'count'=>$yatay_citasi_qty],
+        ['name'=>'Dikey Tek Cam Çıtası','length'=>$dikey_citasi,'count'=>$dikey_citasi_qty],
+        ['name'=>'Dikme','length'=>$dikme,'count'=>$dikme_qty],
+        ['name'=>'Orta Dikme','length'=>$orta_dikme,'count'=>$orta_dikme_qty],
+        ['name'=>'Son Kapatma','length'=>$son_kapatma,'count'=>$son_kapatma_qty],
+        ['name'=>'Kanat','length'=>$kanat,'count'=>$kanat_qty],
+        ['name'=>'Dikey Baza','length'=>$dikey_baza,'count'=>$dikey_baza_qty],
+        ['name'=>'Cam','length'=>$cam_en.' x '.$cam_boy,'count'=>$cam_adet],
+        ['name'=>'Zincir','length'=>$zincir,'count'=>$zincir_qty],
+        ['name'=>'Flatbelt Kayış','length'=>$flatbelt_kayis,'count'=>'-'],
+        ['name'=>'Motor Borusu','length'=>$motor_borusu,'count'=>$motor_borusu_qty],
+        ['name'=>'Motor Kutu Contası (m)','length'=>$motor_kutu_contasi,'count'=>'-'],
+        ['name'=>'Kanat Contası (m)','length'=>$kanat_contasi,'count'=>'-'],
+        ['name'=>'Kenet Fitili (m)','length'=>$kenet_fitili,'count'=>'-'],
+        ['name'=>'Kıl Fitil (m)','length'=>$kil_fitil,'count'=>'-'],
+    ];
+    $total_cost = 0;
+    foreach ($parts as $part) {
+        $stmt = $pdo->prepare('SELECT unit, measure_value, unit_price FROM products WHERE name = ? LIMIT 1');
+        $stmt->execute([$part['name']]);
+        $prod = $stmt->fetch();
+        if ($prod) {
+            $count = is_numeric($part['count']) ? (float)$part['count'] : 0;
+            $length = is_numeric($part['length']) ? (float)$part['length'] : 0;
+            if (strpos($part['name'], '(m)') === false && is_numeric($part['length'])) {
+                $length = $part['length'] / 1000;
+            }
+            switch (strtolower($prod['unit'])) {
+                case 'adet':
+                    $cost = $count * $prod['unit_price'];
+                    break;
+                case 'kg':
+                    $weight = $length * $prod['measure_value'];
+                    $cost = $weight * $count * $prod['unit_price'];
+                    break;
+                default:
+                    $cost = $length * $count * $prod['unit_price'];
+                    break;
+            }
+            $total_cost += $cost;
+        }
+    }
+    return $total_cost;
+}
 $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 $quote = null;
 $guillotines = [];
@@ -43,9 +141,17 @@ if ($id) {
 
 // Handle adding guillotine quote rows
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guillotine']) && $id) {
+    $total = calculateGuillotineCost(
+        $pdo,
+        (float) $_POST['width_mm'],
+        (float) $_POST['height_mm'],
+        (int) $_POST['system_qty'],
+        $_POST['glass_type']
+    );
+    $perUnit = $total / max(1, (int) $_POST['system_qty']);
     $stmt = $pdo->prepare(
-        "INSERT INTO guillotine_quotes (master_quote_id, system_type, width_mm, height_mm, system_qty, glass_type, glass_color, motor_system, remote_qty, ral_code) " .
-        "VALUES (:master, 'Giyotin', :width, :height, :qty, :glass, :color, :motor, :remote_qty, :ral)"
+        "INSERT INTO guillotine_quotes (master_quote_id, system_type, width_mm, height_mm, system_qty, glass_type, glass_color, motor_system, remote_qty, ral_code, cost_per_unit) " .
+        "VALUES (:master, 'Giyotin', :width, :height, :qty, :glass, :color, :motor, :remote_qty, :ral, :cost)"
     );
     $stmt->execute([
         ':master' => $id,
@@ -56,7 +162,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guillotine']) && 
         ':color' => $_POST['glass_color'],
         ':motor' => $_POST['motor_system'],
         ':remote_qty' => $_POST['remote_qty'],
-        ':ral' => $_POST['ral_code']
+        ':ral' => $_POST['ral_code'],
+        ':cost' => $perUnit
     ]);
     $newId = $pdo->lastInsertId();
     $stmtData = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id = :id');
@@ -101,8 +208,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) &&
     $oldStmt->execute([':gid' => $_POST['gid']]);
     $oldData = $oldStmt->fetch();
 
+    $total = calculateGuillotineCost(
+        $pdo,
+        (float) $_POST['width_mm'],
+        (float) $_POST['height_mm'],
+        (int) $_POST['system_qty'],
+        $_POST['glass_type']
+    );
+    $perUnit = $total / max(1, (int) $_POST['system_qty']);
+
     $stmt = $pdo->prepare(
-        "UPDATE guillotine_quotes SET width_mm=:width, height_mm=:height, system_qty=:qty, glass_type=:glass, glass_color=:color, motor_system=:motor, remote_qty=:remote_qty, ral_code=:ral WHERE id=:gid AND master_quote_id=:master"
+        "UPDATE guillotine_quotes SET width_mm=:width, height_mm=:height, system_qty=:qty, glass_type=:glass, glass_color=:color, motor_system=:motor, remote_qty=:remote_qty, ral_code=:ral, cost_per_unit=:cost WHERE id=:gid AND master_quote_id=:master"
     );
     $stmt->execute([
         ':width' => $_POST['width_mm'],
@@ -113,6 +229,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) &&
         ':motor' => $_POST['motor_system'],
         ':remote_qty' => $_POST['remote_qty'],
         ':ral' => $_POST['ral_code'],
+        ':cost' => $perUnit,
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);

--- a/teklif.sql
+++ b/teklif.sql
@@ -3,7 +3,7 @@
 -- https://www.phpmyadmin.net/
 --
 -- Anamakine: 127.0.0.1
--- Üretim Zamanı: 16 Tem 2025, 08:14:33
+-- Üretim Zamanı: 23 Tem 2025, 10:48:03
 -- Sunucu sürümü: 10.4.32-MariaDB
 -- PHP Sürümü: 8.0.30
 
@@ -144,7 +144,12 @@ CREATE TABLE `guillotine_quotes` (
   `remote_qty` int(10) UNSIGNED DEFAULT NULL,
   `ral_code` varchar(50) CHARACTER SET utf8 COLLATE utf8_general_ci DEFAULT NULL,
   `glass_type` varchar(50) DEFAULT NULL,
-  `glass_color` varchar(50) DEFAULT NULL
+  `glass_color` varchar(50) DEFAULT NULL,
+  `discount_rate` decimal(5,2) DEFAULT NULL,
+  `discount_amount` decimal(14,2) DEFAULT NULL,
+  `vat_rate` decimal(5,2) DEFAULT NULL,
+  `vat_amount` decimal(14,2) DEFAULT NULL,
+  `total_with_tax` decimal(14,2) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
 -- --------------------------------------------------------
@@ -209,7 +214,7 @@ CREATE TABLE `products` (
   `measure_value` decimal(10,3) NOT NULL,
   `unit_price` decimal(10,2) NOT NULL,
   `category` varchar(50) DEFAULT NULL,
-  `image_data` LONGBLOB,
+  `image_data` longblob DEFAULT NULL,
   `image_type` varchar(50) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 


### PR DESCRIPTION
## Summary
- compute guillotine system material costs with new `calculateGuillotineCost()` helper
- store calculated `cost_per_unit` when creating or editing guillotine quotes

## Testing
- `php -l offer_form.php`


------
https://chatgpt.com/codex/tasks/task_e_68809f190edc8328aa28de59bef9a2ac