### PR TITLE
Add assembly type combobox

### DIFF
--- a/offer.php
+++ b/offer.php
@@ -38,7 +38,7 @@ $canAdd = count($companies) > 0 && count($customers) > 0;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
     if ($action === 'add') {
-        $stmt = $pdo->prepare("INSERT INTO master_quotes (company_id, contact_id, quote_date, prepared_by, delivery_term, payment_method, payment_due, quote_validity, maturity) VALUES (:company, :contact, :date, :prepared, :delivery, :method, :due, :validity, :maturity)");
+        $stmt = $pdo->prepare("INSERT INTO master_quotes (company_id, contact_id, quote_date, prepared_by, delivery_term, payment_method, payment_due, quote_validity, maturity, assembly_type) VALUES (:company, :contact, :date, :prepared, :delivery, :method, :due, :validity, :maturity, :assembly)");
         $stmt->execute([
             ':company'   => $_POST['company_id'],
             ':contact'   => $_POST['contact_id'],
@@ -48,7 +48,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':method'    => $_POST['payment_method'],
             ':due'       => $_POST['payment_due'],
             ':validity'  => $_POST['quote_validity'],
-            ':maturity'  => $_POST['maturity']
+            ':maturity'  => $_POST['maturity'],
+            ':assembly'  => $_POST['assembly_type']
         ]);
         $newId = $pdo->lastInsertId();
         $stmtData = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
@@ -63,7 +64,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmtOld->execute([':id' => $id]);
         $oldData = $stmtOld->fetch();
 
-        $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id");
+        $stmt = $pdo->prepare("UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity, assembly_type=:assembly WHERE id=:id");
         $stmt->execute([
             ':company'  => $_POST['company_id'],
             ':contact'  => $_POST['contact_id'],
@@ -73,6 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':due'      => $_POST['payment_due'],
             ':validity' => $_POST['quote_validity'],
             ':maturity' => $_POST['maturity'],
+            ':assembly' => $_POST['assembly_type'],
             ':id'       => $id
         ]);
         $stmtNew = $pdo->prepare('SELECT * FROM master_quotes WHERE id = :id');
@@ -171,6 +173,7 @@ include 'includes/header.php';
                     <th>Ödeme Süresi</th>
                     <th>Teklif Süresi</th>
                     <th>Vade</th>
+                    <th>Montaj</th>
                     <th class="text-center actions-col">İşlemler</th>
                 </tr>
             </thead>
@@ -185,6 +188,7 @@ include 'includes/header.php';
                     <td><?php echo htmlspecialchars($q['payment_due']); ?></td>
                     <td><?php echo htmlspecialchars($q['quote_validity']); ?></td>
                     <td><?php echo htmlspecialchars($q['maturity']); ?></td>
+                    <td><?php echo htmlspecialchars($q['assembly_type']); ?></td>
                     <td class="text-center actions-col">
                         <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i
                                 class="bi bi-pencil"></i></a>
@@ -221,7 +225,8 @@ include 'includes/header.php';
                             Ödeme Yöntemi: <?php echo htmlspecialchars($q['payment_method']); ?><br>
                             Ödeme Süresi: <?php echo htmlspecialchars($q['payment_due']); ?><br>
                             Teklif Süresi: <?php echo htmlspecialchars($q['quote_validity']); ?><br>
-                            Vade: <?php echo htmlspecialchars($q['maturity']); ?>
+                            Vade: <?php echo htmlspecialchars($q['maturity']); ?><br>
+                            Montaj: <?php echo htmlspecialchars($q['assembly_type']); ?>
                         </p>
                         <div class="text-end">
                             <a href="offer_form?id=<?php echo $q['id']; ?>" class="btn btn-sm bg-light text-dark"><i

--- a/offer_form.php
+++ b/offer_form.php
@@ -196,7 +196,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
         ':method'    => $_POST['payment_method'],
         ':due'       => $_POST['payment_due'],
         ':validity'  => $_POST['quote_validity'],
-        ':maturity'  => $_POST['maturity']
+        ':maturity'  => $_POST['maturity'],
+        ':assembly'  => $_POST['assembly_type']
     ];
 
     if ($id) {
@@ -206,7 +207,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
 
         $data[':id'] = $id;
         $stmt = $pdo->prepare(
-            "UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity WHERE id=:id"
+            "UPDATE master_quotes SET company_id=:company, contact_id=:contact, quote_date=:date, delivery_term=:delivery, payment_method=:method, payment_due=:due, quote_validity=:validity, maturity=:maturity, assembly_type=:assembly WHERE id=:id"
         );
         $stmt->execute($data);
         $newStmt = $pdo->prepare('SELECT * FROM master_quotes WHERE id=:id');
@@ -216,7 +217,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
     } else {
         $data[':prepared'] = $_SESSION['user']['id'] ?? null;
         $stmt = $pdo->prepare(
-            "INSERT INTO master_quotes (company_id, contact_id, quote_date, prepared_by, delivery_term, payment_method, payment_due, quote_validity, maturity) VALUES (:company, :contact, :date, :prepared, :delivery, :method, :due, :validity, :maturity)"
+            "INSERT INTO master_quotes (company_id, contact_id, quote_date, prepared_by, delivery_term, payment_method, payment_due, quote_validity, maturity, assembly_type) VALUES (:company, :contact, :date, :prepared, :delivery, :method, :due, :validity, :maturity, :assembly)"
         );
         $stmt->execute($data);
         $newId = $pdo->lastInsertId();
@@ -315,6 +316,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
                         <label class="form-label">Vade</label>
                         <input type="text" name="maturity" class="form-control"
                             value="<?php echo $quote ? htmlspecialchars($quote['maturity']) : ''; ?>">
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Montaj</label>
+                        <select name="assembly_type" class="form-select">
+                            <?php
+                            $assemblyOptions = ['Demonte', 'Müşteri Montajlı', 'Bayi Montajlı'];
+                            $currentAssembly = $quote['assembly_type'] ?? '';
+                            foreach ($assemblyOptions as $opt): ?>
+                                <option value="<?php echo $opt; ?>" <?php echo $currentAssembly === $opt ? 'selected' : ''; ?>><?php echo $opt; ?></option>
+                            <?php endforeach; ?>
+                        </select>
                     </div>
                 </div>
             </fieldset>

--- a/teklif.sql
+++ b/teklif.sql
@@ -290,6 +290,7 @@ CREATE TABLE `master_quotes` (
   `payment_due` varchar(50) DEFAULT NULL,
   `quote_validity` varchar(50) DEFAULT NULL,
   `maturity` varchar(50) DEFAULT NULL,
+  `assembly_type` varchar(50) DEFAULT NULL,
   `total_amount` decimal(14,2) DEFAULT NULL,
   `discount_rate` decimal(5,2) DEFAULT NULL,
   `discount_amount` decimal(14,2) DEFAULT NULL,
@@ -302,8 +303,8 @@ CREATE TABLE `master_quotes` (
 -- Tablo döküm verisi `master_quotes`
 --
 
-INSERT INTO `master_quotes` (`id`, `company_id`, `contact_id`, `quote_date`, `prepared_by`, `delivery_term`, `payment_method`, `payment_due`, `quote_validity`, `maturity`, `total_amount`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `taxes_included_total`) VALUES
-(4, 1, 1, '2025-07-21', 1, '30', 'Nakit', '30', '10', '30', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO `master_quotes` (`id`, `company_id`, `contact_id`, `quote_date`, `prepared_by`, `delivery_term`, `payment_method`, `payment_due`, `quote_validity`, `maturity`, `assembly_type`, `total_amount`, `discount_rate`, `discount_amount`, `vat_rate`, `vat_amount`, `taxes_included_total`) VALUES
+(4, 1, 1, '2025-07-21', 1, '30', 'Nakit', '30', '10', '30', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add `assembly_type` field to database dump
- include assembly selection in offer add/edit form
- store assembly type for quotes and display in offer listings

## Testing
- `php -l offer_form.php`
- `php -l offer.php`

------
https://chatgpt.com/codex/tasks/task_e_6881c7b49eb88328b12e257888b82053