### PR TITLE
Compute glass and aluminum costs for quotes

### DIFF
--- a/helpers/cost.php
+++ b/helpers/cost.php
@@ -1,0 +1,48 @@
+<?php
+// Helper for material cost calculations for guillotine quotes
+
+// Fixed aluminum price per kilogram
+const ALUMINUM_PRICE_PER_KG = 190.0;
+
+/**
+ * Calculate material cost for a guillotine system.
+ *
+ * @param PDO   $pdo    Database connection
+ * @param array $quote  Quote data including width_mm, height_mm, system_qty,
+ *                      glass_type and system_type
+ * @return float Total cost in TRY
+ */
+function calculate_guillotine_material_cost(PDO $pdo, array $quote): float
+{
+    $width  = (float)($quote['width_mm'] ?? 0);
+    $height = (float)($quote['height_mm'] ?? 0);
+    $qty    = max(1, (int)($quote['system_qty'] ?? 1));
+    $glass  = $quote['glass_type'] ?? '';
+    $type   = $quote['system_type'] ?? 'Giyotin';
+
+    if ($width <= 0 || $height <= 0) {
+        return 0.0;
+    }
+
+    // Fetch glass unit price from products table
+    $stmt = $pdo->prepare('SELECT unit_price FROM products WHERE name = ? LIMIT 1');
+    $stmt->execute([$glass]);
+    $glassPrice = (float)$stmt->fetchColumn();
+    if ($glassPrice <= 0) {
+        $glassPrice = 0.0;
+    }
+
+    $area = ($width / 1000) * ($height / 1000); // m²
+    $glassCost = $area * $glassPrice * $qty;
+
+    // Predefined aluminum weight per m² for different system types
+    $weightMap = [
+        'Giyotin' => 10.0,
+    ];
+    $weightPerSqm = $weightMap[$type] ?? $weightMap['Giyotin'];
+    $alWeight = $area * $weightPerSqm * $qty;
+    $alCost = $alWeight * ALUMINUM_PRICE_PER_KG;
+
+    return round($glassCost + $alCost, 2);
+}
+?>

--- a/offer_form.php
+++ b/offer_form.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/cost.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -59,6 +60,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['add_guillotine']) && 
         ':ral' => $_POST['ral_code']
     ]);
     $newId = $pdo->lastInsertId();
+    $cost = calculate_guillotine_material_cost($pdo, [
+        'width_mm' => $_POST['width_mm'],
+        'height_mm' => $_POST['height_mm'],
+        'system_qty' => max(0, (int)$_POST['system_qty']),
+        'glass_type' => $_POST['glass_type'],
+        'system_type' => 'Giyotin'
+    ]);
+    $upd = $pdo->prepare('UPDATE guillotine_quotes SET total_price = ? WHERE id = ?');
+    $upd->execute([$cost, $newId]);
     $stmtData = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id = :id');
     $stmtData->execute([':id' => $newId]);
     $newData = $stmtData->fetch();
@@ -116,6 +126,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['edit_guillotine']) &&
         ':gid' => $_POST['gid'],
         ':master' => $id
     ]);
+    $cost = calculate_guillotine_material_cost($pdo, [
+        'width_mm' => $_POST['width_mm'],
+        'height_mm' => $_POST['height_mm'],
+        'system_qty' => max(0, (int)$_POST['system_qty']),
+        'glass_type' => $_POST['glass_type'],
+        'system_type' => 'Giyotin'
+    ]);
+    $upd = $pdo->prepare('UPDATE guillotine_quotes SET total_price = ? WHERE id = ?');
+    $upd->execute([$cost, (int)$_POST['gid']]);
     $newStmt = $pdo->prepare('SELECT * FROM guillotine_quotes WHERE id=:gid');
     $newStmt->execute([':gid' => $_POST['gid']]);
     $newData = $newStmt->fetch();


### PR DESCRIPTION
## Summary
- add cost helper for guillotine quotes
- compute total price when creating or updating guillotine quote rows

## Testing
- `php -l helpers/cost.php`
- `php -l offer_form.php`


------
https://chatgpt.com/codex/tasks/task_e_688344e7a2488328a1d8602eccc18b10