### PR TITLE
Implement waste margin for aluminum cost

### DIFF
--- a/helpers/cost.php
+++ b/helpers/cost.php
@@ -2,7 +2,7 @@
 // Helper for material cost calculations for guillotine quotes
 
 // Fixed aluminum price per kilogram
-const ALUMINUM_PRICE_PER_KG = 190.0;
+const ALUMINUM_PRICE_PER_KG = 202.77;
 
 /**
  * Calculate material cost for a guillotine system.
@@ -41,7 +41,15 @@ function calculate_guillotine_material_cost(PDO $pdo, array $quote): float
     ];
     $weightPerSqm = $weightMap[$type] ?? $weightMap['Giyotin'];
     $alWeight = $area * $weightPerSqm * $qty;
-    $alCost = $alWeight * ALUMINUM_PRICE_PER_KG;
+
+    // Base aluminum cost without waste
+    $baseAlCost = $alWeight * ALUMINUM_PRICE_PER_KG;
+
+    // Additional waste allowance of 7%
+    $wasteWeight = $alWeight * 0.07;
+    $wasteCost = $wasteWeight * ALUMINUM_PRICE_PER_KG;
+
+    $alCost = $baseAlCost + $wasteCost;
 
     return round($glassCost + $alCost, 2);
 }

--- a/offer_form.php
+++ b/offer_form.php
@@ -557,6 +557,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
                     <th>Motor</th>
                     <th>Adet</th>
                     <th>RAL Kod</th>
+                    <th>Maliyet (₺)</th>
                     <th class="text-center actions-col">İşlemler</th>
                 </tr>
             </thead>
@@ -572,6 +573,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
                     <td><?php echo htmlspecialchars($g['motor_system']); ?></td>
                     <td><?php echo htmlspecialchars($g['remote_qty']); ?></td>
                     <td><?php echo htmlspecialchars($g['ral_code']); ?></td>
+                    <td><?php echo number_format((float)$g['total_price'], 2); ?></td>
                     <td class="text-center">
                         <button class="btn btn-sm bg-light text-dark edit-guillotine-btn" data-bs-toggle="modal"
                             data-bs-target="#giyotinModal" data-id="<?php echo $g['id']; ?>"

--- a/optimization.php
+++ b/optimization.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['user'])) {
 load_theme_settings($pdo);
 
 // Default aluminum price per kilogram in TRY
-const ALUMINUM_COST_PER_KG = 202.39;
+const ALUMINUM_COST_PER_KG = 202.77;
 
 $results = [];
 $width = '';


### PR DESCRIPTION
## Summary
- adjust aluminum unit price to 202.77₺
- apply 7% scrap allowance when calculating aluminum cost
- update optimization constant to the new price

## Testing
- `php -l helpers/cost.php`
- `php -l optimization.php`


------
https://chatgpt.com/codex/tasks/task_e_68834695d49883288f898c6cee12cddf