### PR TITLE
Add validation helper

### DIFF
--- a/helpers/validation.php
+++ b/helpers/validation.php
@@ -1,0 +1,41 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+/**
+ * Sanitize a string by trimming and escaping special characters.
+ */
+function sanitize_string(string $value): string
+{
+    $value = trim($value);
+    return filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+}
+
+/**
+ * Validate an email address and return sanitized email or null on failure.
+ */
+function validate_email(string $email): ?string
+{
+    $email = filter_var(trim($email), FILTER_VALIDATE_EMAIL);
+    return $email ?: null;
+}
+
+/**
+ * Validate an integer and return it or null.
+ */
+function validate_int($value): ?int
+{
+    $result = filter_var($value, FILTER_VALIDATE_INT);
+    return ($result !== false) ? (int)$result : null;
+}
+
+/**
+ * Validate a float and return it or null.
+ */
+function validate_float($value): ?float
+{
+    $result = filter_var($value, FILTER_VALIDATE_FLOAT);
+    return ($result !== false) ? (float)$result : null;
+}
+?>

--- a/login.php
+++ b/login.php
@@ -1,6 +1,7 @@
 <?php
 require_once 'config.php';
 require_once 'helpers/theme.php';
+require_once 'helpers/validation.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -10,7 +11,7 @@ $errors = [];
 $username = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username'] ?? '');
+    $username = sanitize_string($_POST['username'] ?? '');
     $password = $_POST['password'] ?? '';
 
     if ($username === '' || $password === '') {

--- a/profile.php
+++ b/profile.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/validation.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -16,15 +17,19 @@ $success = '';
 $userId = $_SESSION['user']['id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $firstName = trim($_POST['first_name'] ?? '');
-    $lastName  = trim($_POST['last_name'] ?? '');
-    $username  = trim($_POST['username'] ?? '');
-    $email     = trim($_POST['email'] ?? '');
+    $firstName = sanitize_string($_POST['first_name'] ?? '');
+    $lastName  = sanitize_string($_POST['last_name'] ?? '');
+    $username  = sanitize_string($_POST['username'] ?? '');
+    $email     = validate_email($_POST['email'] ?? '') ?? '';
     $password  = $_POST['password'] ?? '';
 
-    if ($firstName === '' || $lastName === '' || $username === '' || $email === '') {
+    if ($firstName === '' || $lastName === '' || $username === '') {
         $errors[] = 'Tüm alanları doldurun.';
-    } else {
+    }
+    if (!$email) {
+        $errors[] = 'Geçersiz e-posta adresi.';
+    }
+    if (!$errors) {
         try {
             $stmt = $pdo->prepare('SELECT id FROM users WHERE (username = ? OR email = ?) AND id != ?');
             $stmt->execute([$username, $email, $userId]);

--- a/register.php
+++ b/register.php
@@ -2,6 +2,7 @@
 require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
+require_once 'helpers/validation.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -11,15 +12,19 @@ $errors = [];
 $success = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $firstName = trim($_POST['firstName'] ?? '');
-    $lastName = trim($_POST['lastName'] ?? '');
-    $username = trim($_POST['username'] ?? '');
+    $firstName = sanitize_string($_POST['firstName'] ?? '');
+    $lastName = sanitize_string($_POST['lastName'] ?? '');
+    $username = sanitize_string($_POST['username'] ?? '');
     $password = $_POST['password'] ?? '';
-    $email = trim($_POST['email'] ?? '');
+    $email = validate_email($_POST['email'] ?? '') ?? '';
 
-    if ($firstName === '' || $lastName === '' || $username === '' || $password === '' || $email === '') {
+    if ($firstName === '' || $lastName === '' || $username === '' || $password === '') {
         $errors[] = 'Tüm alanları doldurun.';
-    } else {
+    }
+    if (!$email) {
+        $errors[] = 'Geçersiz e-posta adresi.';
+    }
+    if (!$errors) {
         try {
             $stmt = $pdo->prepare('SELECT id FROM users WHERE username = ? OR email = ?');
             $stmt->execute([$username, $email]);


### PR DESCRIPTION
## Summary
- add common validation helpers for sanitizing input
- use new helpers in login, register and profile forms to prevent XSS/SQL injection

## Testing
- `php -l helpers/validation.php`
- `php -l login.php`
- `php -l register.php`
- `php -l profile.php`


------
https://chatgpt.com/codex/tasks/task_e_6883733f9c808328930e33ffb602a689