### PR TITLE
Refactor optimization logic and add utilities

### DIFF
--- a/helpers/settings.php
+++ b/helpers/settings.php
@@ -4,10 +4,14 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 
 const APP_DEFAULT_SETTINGS = [
-    'order_email' => 'orders@example.com',
-    'currency'    => 'USD',
-    'timezone'    => 'UTC',
-    'date_format' => 'Y-m-d H:i',
+    'order_email'           => 'orders@example.com',
+    'currency'              => 'USD',
+    'timezone'              => 'UTC',
+    'date_format'           => 'Y-m-d H:i',
+    // Pricing related defaults
+    'aluminum_cost_per_kg'  => 202.77,
+    'glass_cost_per_sqm'    => 1295.26,
+    'monthly_interest_rate' => 0.05,
 ];
 
 function get_setting(PDO $pdo, string $key)

--- a/helpers/utils.php
+++ b/helpers/utils.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+function fmt_currency(float $value, int $decimals = 0): string
+{
+    return number_format($value, $decimals);
+}
+
+function csrf_token(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validate_csrf_token(?string $token): bool
+{
+    return hash_equals($_SESSION['csrf_token'] ?? '', $token ?? '');
+}
+


### PR DESCRIPTION
## Summary
- centralize app defaults in settings
- add utility helpers for formatting and CSRF tokens
- refactor optimization page into reusable function with bulk product lookup
- use dynamic settings for material costs and interest rate
- add CSRF protection and common currency formatting

## Testing
- `php -l helpers/utils.php`
- `php -l helpers/settings.php`
- `php -l optimization.php`


------
https://chatgpt.com/codex/tasks/task_e_688387cb109883289f835f68f13468a1