### PR TITLE
Fix profit margin calculation

### DIFF
--- a/optimization.php
+++ b/optimization.php
@@ -260,7 +260,12 @@ function calculateOptimization(array $input, PDO $pdo): array
         $totalCost = 0.0;
     }
 
-    $salesPrice = max(0, $totalCost * (1 + $profitMargin / 100));
+    $marginFactor = 1 - ($profitMargin / 100);
+    if ($marginFactor > 0) {
+        $salesPrice = max(0, $totalCost / $marginFactor);
+    } else {
+        $salesPrice = 0.0;
+    }
     $calculatedMargin = $salesPrice > 0 ? (($salesPrice - $totalCost) / $salesPrice) * 100 : 0.0;
     $profitMarginAmount = $salesPrice - $totalCost;
 


### PR DESCRIPTION
## Summary
- compute the sales price based on the desired margin
- avoid division by zero when profit margin is 100% or more

## Testing
- `php -l optimization.php`


------
https://chatgpt.com/codex/tasks/task_e_68838f4e454c83288f0d3e6f522abe49