### PR TITLE
Fix update logic after profit margin calculation

### DIFF
--- a/offer_form.php
+++ b/offer_form.php
@@ -3,6 +3,7 @@ require_once 'config.php';
 require_once 'helpers/theme.php';
 require_once 'helpers/audit.php';
 require_once 'helpers/cost.php';
+require_once 'helpers/utils.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -677,7 +678,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $canAdd) {
             form.method = 'post';
             form.action = '/optimization.php';
             form.target = '_blank';
+            const csrf = <?php echo json_encode(csrf_token()); ?>;
             form.innerHTML =
+                '<input type="hidden" name="csrf_token" value="' + csrf + '">' +
                 '<input type="hidden" name="width" value="' + width + '">' +
                 '<input type="hidden" name="height" value="' + height + '">' +
                 '<input type="hidden" name="quantity" value="' + quantity + '">' +

--- a/optimization.php
+++ b/optimization.php
@@ -315,7 +315,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' || (!empty($input['width']) && !empty(
         }
         $returnPrice = isset($input['return']);
         $data = calculateOptimization($input, $pdo);
-        if ($offerId && $offerExists && !empty($input['gid']) && empty($data['errors'])) {
+        if (
+            $_SERVER['REQUEST_METHOD'] === 'POST' &&
+            isset($input['profit_margin']) &&
+            $offerId && $offerExists && !empty($input['gid']) &&
+            empty($data['errors'])
+        ) {
             try {
                 $stmt = $pdo->prepare('UPDATE guillotine_quotes SET total_price=?, profit_margin_rate=?, profit_margin_amount=? WHERE id=?');
                 $stmt->execute([


### PR DESCRIPTION
## Summary
- load utility helpers in offer form so CSRF tokens are available
- send CSRF token when opening optimization window
- only save quote after POST with profit margin calculated

## Testing
- `php -l offer_form.php`
- `php -l optimization.php`

------
https://chatgpt.com/codex/tasks/task_e_68839073cc688328833711c5b417c3eb