### PR TITLE
Add .gitignore for PHP projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Dependency directories
+/vendor/
+
+# Temporary files
+/tmp/
+/temp/
+/cache/
+
+# Logs
+*.log
+
+# IDE directories
+.idea/
+.vscode/
+nbproject/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Swap files
+*~
+*.swp


### PR DESCRIPTION
## Summary
- add common PHP ignores like `/vendor/`, IDE folders, and temp files

## Testing
- `find . -path ./vendor -prune -o -name "*.php" -print0 | xargs -0 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6887106aea948328885898429f851dab